### PR TITLE
Laying the groundwork for default landingTarget

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -987,7 +987,7 @@ Mission Mission::Instantiate(const PlayerInfo &player) const
 	
 	// Instantiate the NPCs. This also fills in the "<npc>" substitution.
 	for(const NPC &npc : npcs)
-		result.npcs.push_back(npc.Instantiate(subs, player.GetSystem(), result.destination->GetSystem()));
+		result.npcs.push_back(npc.Instantiate(subs, player.GetSystem(), result.destination));
 	
 	// Instantiate the actions. The "complete" action is always first so that
 	// the "<payment>" substitution can be filled in.

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -363,9 +363,10 @@ bool NPC::HasFailed() const
 
 // Create a copy of this NPC but with the fleets replaced by the actual
 // ships they represent, wildcards in the conversation text replaced, etc.
-NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const System *destination) const
+NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Planet *destinationPlanet) const
 {
 	NPC result;
+	const System *destination = destinationPlanet->GetSystem();
 	result.government = government;
 	if(!result.government)
 		result.government = GameData::PlayerGovernment();
@@ -375,6 +376,7 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 	result.mustEvade = mustEvade;
 	result.mustAccompany = mustAccompany;
 	result.targetSystem = needsTravelTarget ? destination : targetSystem;
+	result.landingTarget = needsLandingTarget ? destinationPlanet : landingTarget;
 	
 	// Pick the system for this NPC to start out in.
 	result.system = system;

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -56,7 +56,7 @@ public:
 	
 	// Create a copy of this NPC but with the fleets replaced by the actual
 	// ships they represent, wildcards in the conversation text replaced, etc.
-	NPC Instantiate(std::map<std::string, std::string> &subs, const System *origin, const System *destination) const;
+	NPC Instantiate(std::map<std::string, std::string> &subs, const System *origin, const Planet *destinationPlanet) const;
 	
 	
 private:


### PR DESCRIPTION
```
NPC::Instantiate now brings in destinationPlanet, so just specifying
"land" in an NPC spec can default to landing at the destination planet.
```