### PR TITLE
Mission success/failure handling

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -561,7 +561,7 @@ void Engine::Step(bool isActive)
 			info.SetBar("target hull", 0.);
 		}
 	}
-	if(target && !target->IsDestroyed() && target->GetSystem() == currentSystem 
+	if(target && !target->IsDestroyed() && !target->HasLanded() && target->GetSystem() == currentSystem 
 		&& (flagship->CargoScanFraction() || flagship->OutfitScanFraction()))
 	{
 		double width = max(target->Width(), target->Height());

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -409,8 +409,6 @@ bool NPC::IsLeftBehind(const System *playerSystem) const
 
 bool NPC::HasFailed() const
 {
-	static const int mustLiveFor = ShipEvent::SCAN_CARGO | ShipEvent::SCAN_OUTFITS | ShipEvent::BOARD;
-	
 	for(const auto &it : actions)
 	{
 		if(it.second & failIf)
@@ -418,7 +416,7 @@ bool NPC::HasFailed() const
 	
 		// If we still need to perform an action that requires the NPC ship be
 		// alive, then that ship being destroyed should cause the mission to fail.
-		if((~it.second & succeedIf & mustLiveFor) && (it.second & (ShipEvent::DESTROY | ShipEvent::LAND)))
+		if((~it.second & succeedIf) && (it.second & (ShipEvent::DESTROY | ShipEvent::LAND)))
 			return true;
 	}
 	

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1802,7 +1802,7 @@ void Ship::Restore()
 // Check if this ship has been destroyed.
 bool Ship::IsDestroyed() const
 {
-	return (hull < 0.);
+	return (hull < 0.) && !hasLanded;
 }
 
 


### PR DESCRIPTION
Also fixed an issue where scan circles would be visible after a ship permanently lands.

(Okay, I technically _caused_ the issue, but only because I made sure IsDestroyed isn't true for a permanently landed ship.)

Background: an hour before MZ merged my NPCDestroyFail feature, with the `mustLiveFor` bitmask, I realised it didn't need to exist. The first commit here removes it, as maintaining it in light of the new land stuff would be even sillier.