### PR TITLE
Reduce time spent searching for targets in AI::FindTarget

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -265,6 +265,9 @@ void AI::Step(const PlayerInfo &player)
 					break;
 				}
 		}
+	// Remove expired weak_ptr from the rosters.
+	if(!Random::Int(1200))
+		CleanRosters();
 	enemyStrength.clear();
 	allyStrength.clear();
 	for(const auto &it : strength)
@@ -2870,6 +2873,17 @@ bool AI::Has(const Government *government, const weak_ptr<const Ship> &other, in
 		return false;
 	
 	return (oit->second & type);
+}
+
+
+
+// Remove expired weak_ptrs from the ship rosters.
+void AI::CleanRosters()
+{
+	for(auto &govt : governmentRosters)
+		for(auto &sit : govt.second)
+			if(sit.first.expired())
+				govt.second.erase(sit.first);
 }
 
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -763,7 +763,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	if(!person.IsHeroic() && strengthIt != shipStrength.end())
 		maxStrength = 2 * strengthIt->second;
 	
-	// Get list of all other hostile targets in this system.
+	// Get list of all hostile targets in this system.
 	vector<shared_ptr<Ship>> enemies = GetShipsList(ship, true);
 	for(const shared_ptr<Ship> foe : enemies)
 	{
@@ -835,7 +835,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	if(!target && (cargoScan || outfitScan) && !isPlayerEscort)
 	{
 		closest = numeric_limits<double>::infinity();
-		vector<shared_ptr<Ship>> allies = GetShipsList(ship, false, closest);
+		vector<shared_ptr<Ship>> allies = GetShipsList(ship, false);
 		for(const shared_ptr<Ship> it : allies)
 			if(it->GetGovernment() != gov)
 			{
@@ -2041,10 +2041,8 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
 		// Extend the weapon range slightly to account for velocity differences.
 		maxRange *= 1.5;
 		
-		// Now, get all enemy ships within that radius.
+		// Now, get all enemy ships within that radius, and the targeted ship (if able).
 		enemies = GetShipsList(ship, true, maxRange);
-		if(currentTarget)
-			enemies.push_back(currentTarget);
 	}
 	else
 		enemies.push_back(currentTarget);
@@ -2104,8 +2102,9 @@ void AI::AimTurrets(const Ship &ship, Command &command, bool opportunistic) cons
 			double bestAngle = 0.;
 			for(shared_ptr<const Ship> target : enemies)
 			{
-				// Only aim turrets at a disabled enemy if it is the only choice.
-				if(target->IsDisabled() && enemies.size() > 1)
+				// Only aim turrets at a disabled enemy if it is the only
+				// choice, or the ship's target.
+				if(target->IsDisabled() && (enemies.size() > 1 || target.get() != currentTarget.get()))
 					continue;
 				
 				Point p = target->Position() - start;

--- a/source/AI.h
+++ b/source/AI.h
@@ -67,7 +67,7 @@ template <class Type>
 private:
 	// Pick a new target for the given ship.
 	std::shared_ptr<Ship> FindTarget(const Ship &ship) const;
-	std::vector<std::shared_ptr<Ship>> GetEnemyList(const Ship &ship, double maxRange = -1.) const;
+	std::vector<std::shared_ptr<Ship>> GetShipsList(const Ship &ship, const bool ifEnemy, double maxRange = -1.) const;
 	
 	bool FollowOrders(Ship &ship, Command &command) const;
 	void MoveIndependent(Ship &ship, Command &command) const;

--- a/source/AI.h
+++ b/source/AI.h
@@ -20,6 +20,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <list>
 #include <map>
 #include <memory>
+#include <vector>
 
 class Angle;
 class AsteroidField;
@@ -66,6 +67,7 @@ template <class Type>
 private:
 	// Pick a new target for the given ship.
 	std::shared_ptr<Ship> FindTarget(const Ship &ship) const;
+	std::vector<std::shared_ptr<Ship>> GetEnemyList(const Ship &ship, double maxRange = -1.) const;
 	
 	bool FollowOrders(Ship &ship, Command &command) const;
 	void MoveIndependent(Ship &ship, Command &command) const;

--- a/source/AI.h
+++ b/source/AI.h
@@ -116,6 +116,7 @@ private:
 	
 	bool Has(const Ship &ship, const std::weak_ptr<const Ship> &other, int type) const;
 	bool Has(const Government *government, const std::weak_ptr<const Ship> &other, int type) const;
+	void CleanRosters();
 	
 	
 private:

--- a/source/AI.h
+++ b/source/AI.h
@@ -180,6 +180,7 @@ private:
 	
 	std::map<const Government *, int64_t> enemyStrength;
 	std::map<const Government *, int64_t> allyStrength;
+	std::map<const Government *, std::map<std::weak_ptr<Ship>, Point, Comp>> governmentRosters;
 };
 
 


### PR DESCRIPTION
When building the government strength comparison for the player's system, also create a roster of ships belonging to the given government.
This reduces the number of ships that need to be iterated when determining which hostile ship should be targeted, as only hostile targets need to be compared.

This"government roster" is a stepping stone in the path to improved group logic from ai controlled ships