### PR TITLE
Merge "add fleet" and "add variant" declarations with existing fleet/variant definition 

### DIFF
--- a/source/System.h
+++ b/source/System.h
@@ -64,6 +64,8 @@ public:
 		
 		const Fleet *Get() const;
 		int Period() const;
+		void AddPeriod(int period);
+		void SetPeriod(int period);
 		
 	private:
 		const Fleet *fleet;


### PR DESCRIPTION
1) This prevents the need for multiple "remove fleet" or "remove variant" uses in a game event, as there will  be at most one of any specific fleet definition in System::Fleets(), or at most one of any specific variant in Fleet::Variants().
(There are currently no duplicated fleet variant specifications, but to preserve conceptual conformity - "remove ___" means the ____ is gone from its container - the Fleet.cpp change is required)

2) For system fleet definitions, the "set period" keyword is defined. It is used exactly as "add" or "remove" would be, e.g. `"set period" fleet "Small Southern Merchants" 1000`. If the `Small Southern Merchants` fleet exists, its period will become 1000, no matter if it was previously 100 or 20000. If the `Small Southern Merchants` fleet does not exist in the system, it will be inserted with period 1000.
This means "set period" can effectively replace the use of "add" as a keyword for changes to a system's fleet definitions, and the keyword "remove" is needed only for situations in which a specific fleet is completely removed from the system's fleets, rather than paired with "add" to create situations in which the fleet's presence is to be reduced.

Combined, these two changes minimize the number of lines needed to implement incremental changes to system fleets and fleet variants.
Example: 
Applying add/remove to the FW campaign, largely in full, is +1353 / -1233: https://github.com/tehhowch/endless-sky/pull/21
Applying add/remove with automerge and "set period", and also making every FW event incremental (except "pug flee" and the final Deneb specification), is +1359 / -1339: https://github.com/tehhowch/endless-sky/pull/23