### PR TITLE
FW Campaign events use incremental fleet definitions

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -16,7 +16,7 @@ event "remembrance day"
 mission "remembrance day"
 	landing
 	source
-		government "Republic"
+		government Republic
 	to offer
 		has "event: remembrance day"
 	on offer
@@ -38,53 +38,53 @@ event "war begins"
 		fleet "Large Southern Merchants" 1400
 		fleet "Small Free Worlds" 600
 		fleet "Large Free Worlds" 1300
-	system "Spica"
+	system Spica
 		government "Free Worlds"
-	system "Minkar"
+	system Minkar
 		government "Free Worlds"
-	system "Acrux"
+	system Acrux
 		government "Free Worlds"
-	system "Mimosa"
+	system Mimosa
 		government "Free Worlds"
-	system "Kraz"
+	system Kraz
 		government "Free Worlds"
-	system "Izar"
+	system Izar
 		government "Free Worlds"
 	system "Zeta Centauri"
 		government "Free Worlds"
-	system "Hadar"
+	system Hadar
 		government "Free Worlds"
-	system "Alkaid"
+	system Alkaid
 		government "Free Worlds"
-	system "Zubeneschamali"
+	system Zubeneschamali
 		government "Free Worlds"
-	system "Kochab"
+	system Kochab
 		government "Free Worlds"
-	system "Ildaria"
+	system Ildaria
 		government "Free Worlds"
-	system "Zubenelgenubi"
+	system Zubenelgenubi
 		government "Free Worlds"
-	system "Sabik"
+	system Sabik
 		government "Free Worlds"
-	system "Unukalhai"
+	system Unukalhai
 		government "Free Worlds"
-	system "Kornephoros"
+	system Kornephoros
 		government "Free Worlds"
-	system "Sargas"
+	system Sargas
 		government "Free Worlds"
-	system "Lesath"
+	system Lesath
 		government "Free Worlds"
-	system "Aldhibain"
+	system Aldhibain
 		government "Free Worlds"
-	system "Dschubba"
+	system Dschubba
 		government "Free Worlds"
-	system "Atria"
+	system Atria
 		government "Free Worlds"
-	system "Alniyat"
+	system Alniyat
 		government "Free Worlds"
-	system "Han"
+	system Han
 		government "Free Worlds"
-	system "Pherkad"
+	system Pherkad
 		government "Free Worlds"
 	system "Yed Prior"
 		government "Free Worlds"
@@ -92,12 +92,12 @@ event "war begins"
 		government "Free Worlds"
 	system "Kappa Centauri"
 		government "Free Worlds"
-	system "Castor"
+	system Castor
 		fleet "Small Northern Merchants" 800
 		fleet "Large Northern Merchants" 1100
 		fleet "Small Republic" 800
 		fleet "Large Republic" 400
-	system "Pollux"
+	system Pollux
 		fleet "Small Northern Merchants" 700
 		fleet "Large Northern Merchants" 1100
 		fleet "Small Republic" 700
@@ -117,18 +117,18 @@ event "war begins"
 		fleet "Large Northern Merchants" 4000
 		fleet "Small Republic" 1100
 		fleet "Large Republic" 1300
-	planet "Geminus"
+	planet Geminus
 		description `Until recently, Geminus was home to the Republic Navy Yard, the largest shipyard in human space. Now, there is nothing left of the shipyard but a gaping crater in the ground, from the recent terrorist bombing.`
 		spaceport `Fortunately, the spaceport and residential areas survived the bombing, which was focused only on the Navy yard and happened early in the morning, when very few people were at work.`
 		spaceport `The Navy officers who are in charge here have no time for anyone who is not enlisted in the Navy and participating in the ongoing investigation.`
 		shipyard clear
 		outfitter clear
 		"required reputation" 100
-	planet "Martini"
+	planet Martini
 		description `Martini is a world of exotic beaches and perfect weather. The Republic's central bank and the galactic stock exchange were previously headquartered here, before a terrorist attack destroyed them and a large portion of the capital city as well.`
 		"required reputation" 100
 		security .9
-	planet "Bourne"
+	planet Bourne
 		add description `Bourne is also the seat of government for the newly formed Coalition of Free Worlds.`
 
 mission "event: war begins"
@@ -148,27 +148,27 @@ mission "event: war begins"
 
 event "initial deployment 1"
 	date 24 7 3014
-	system "Spica"
+	system Spica
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 1700
 		fleet "Small Free Worlds" 800
 		fleet "Large Free Worlds" 1500
-	system "Minkar"
+	system Minkar
 		fleet "Small Southern Merchants" 700
 		fleet "Large Southern Merchants" 1500
 		fleet "Small Free Worlds" 700
 		fleet "Large Free Worlds" 1200
-	system "Mimosa"
+	system Mimosa
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 2300
 		fleet "Small Free Worlds" 1200
 		fleet "Large Free Worlds" 1900
-	system "Kraz"
+	system Kraz
 		fleet "Small Southern Merchants" 900
 		fleet "Large Southern Merchants" 1600
 		fleet "Small Free Worlds" 700
 		fleet "Large Free Worlds" 900
-	system "Acrux"
+	system Acrux
 		fleet "Small Southern Merchants" 500
 		fleet "Large Southern Merchants" 800
 		fleet "Small Free Worlds" 700
@@ -181,9 +181,9 @@ event "initial deployment 1"
 		fleet "Small Republic" 600
 		fleet "Large Republic" 400
 		fleet "Navy Surveillance" 2000
-	planet "Ingot"
+	planet Ingot
 		add description `Ingot is also now home to a burgeoning Navy base, although since the planet is so unlivable most of the troops are just living in ships in orbit.`
-	system "Fala"
+	system Fala
 		fleet "Small Northern Merchants" 1900
 		fleet "Large Northern Merchants" 3500
 		fleet "Small Republic" 600
@@ -191,13 +191,13 @@ event "initial deployment 1"
 		fleet "Small Northern Pirates" 4000
 		fleet "Large Northern Pirates" 8000
 		fleet "Navy Surveillance" 2000
-	system "Phecda"
+	system Phecda
 		fleet "Small Northern Merchants" 900
 		fleet "Small Southern Merchants" 1100
 		fleet "Small Republic" 900
 		fleet "Large Republic" 1100
 		fleet "Navy Surveillance" 2000
-	system "Algorel"
+	system Algorel
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 1200
 		fleet "Small Republic" 700
@@ -207,35 +207,35 @@ event "initial deployment 1"
 		fleet "Navy Surveillance" 2000
 	planet "New Wales"
 		add description `The Republic Navy has planted a base on New Wales: so far, just a densely packed cluster of prefabricated barracks and infirmary buildings on the outskirts of one of the mining colonies.`
-	system "Porrima"
+	system Porrima
 		fleet "Small Southern Merchants" 1400
 		fleet "Large Southern Merchants" 4000
 		fleet "Small Republic" 1200
 		fleet "Large Republic" 1800
 		fleet "Small Southern Pirates" 9000
 		fleet "Navy Surveillance" 2000
-	system "Ipsing"
+	system Ipsing
 		fleet "Small Southern Merchants" 2800
 		fleet "Large Southern Merchants" 7000
 		fleet "Small Republic" 2500
 		fleet "Large Republic" 4000
 		fleet "Small Southern Pirates" 5000
 		fleet "Navy Surveillance" 2000
-	system "Mizar"
+	system Mizar
 		fleet "Small Southern Merchants" 1400
 		fleet "Large Southern Merchants" 4500
 		fleet "Small Republic" 1000
 		fleet "Large Republic" 1400
 		fleet "Small Southern Pirates" 9000
 		fleet "Navy Surveillance" 2000
-	system "Muphrid"
+	system Muphrid
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 4800
 		fleet "Small Republic" 1100
 		fleet "Large Republic" 1900
 		fleet "Small Southern Pirates" 9000
 		fleet "Navy Surveillance" 2000
-	system "Menkent"
+	system Menkent
 		fleet "Small Southern Merchants" 700
 		fleet "Large Southern Merchants" 1900
 		fleet "Small Republic" 500
@@ -251,9 +251,9 @@ event "initial deployment 1"
 
 event "initial deployment 2"
 	date 14 8 3014
-	planet "Martini"
+	planet Martini
 		"required reputation" 10
-	system "Izar"
+	system Izar
 		fleet "Small Southern Merchants" 500
 		fleet "Large Southern Merchants" 1500
 		fleet "Small Free Worlds" 700
@@ -265,31 +265,31 @@ event "initial deployment 2"
 		fleet "Large Free Worlds" 2000
 		fleet "Small Southern Pirates" 6000
 		fleet "Large Southern Pirates" 9000
-	system "Hadar"
+	system Hadar
 		fleet "Small Southern Merchants" 400
 		fleet "Large Southern Merchants" 600
 		fleet "Small Free Worlds" 600
 		fleet "Large Free Worlds" 1100
-	system "Alkaid"
+	system Alkaid
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 4000
 		fleet "Small Free Worlds" 6000
 		fleet "Large Free Worlds" 10000
 		fleet "Small Southern Pirates" 4000
 		fleet "Large Southern Pirates" 8000
-	system "Zubeneschamali"
+	system Zubeneschamali
 		fleet "Small Southern Merchants" 500
 		fleet "Large Southern Merchants" 1000
 		fleet "Small Free Worlds" 1400
 		fleet "Large Free Worlds" 2400
 		fleet "Small Southern Pirates" 4000
 		fleet "Large Southern Pirates" 5000
-	system "Kochab"
+	system Kochab
 		fleet "Small Southern Merchants" 1800
 		fleet "Large Southern Merchants" 5000
 		fleet "Small Southern Pirates" 6000
 		fleet "Small Free Worlds" 5000
-	system "Ildaria"
+	system Ildaria
 		fleet "Small Southern Merchants" 900
 		fleet "Large Southern Merchants" 1800
 		fleet "Small Free Worlds" 2200
@@ -297,7 +297,7 @@ event "initial deployment 2"
 		fleet "Small Southern Pirates" 4000
 		fleet "Large Southern Pirates" 7000
 	
-	system "Mora"
+	system Mora
 		fleet "Small Southern Merchants" 2800
 		fleet "Large Southern Merchants" 5000
 		fleet "Small Southern Pirates" 3000
@@ -313,7 +313,7 @@ event "initial deployment 2"
 		fleet "Small Republic" 1600
 		fleet "Large Republic" 2400
 		fleet "Navy Surveillance" 1600
-	system "Turais"
+	system Turais
 		fleet "Small Southern Merchants" 2000
 		fleet "Large Southern Merchants" 6000
 		fleet "Small Southern Pirates" 3000
@@ -321,7 +321,7 @@ event "initial deployment 2"
 		fleet "Small Republic" 1000
 		fleet "Large Republic" 1800
 		fleet "Navy Surveillance" 1600
-	system "Gacrux"
+	system Gacrux
 		fleet "Small Southern Merchants" 2000
 		fleet "Large Southern Merchants" 5000
 		fleet "Small Southern Pirates" 2000
@@ -336,14 +336,14 @@ event "initial deployment 2"
 		fleet "Small Republic" 1200
 		fleet "Large Republic" 1800
 		fleet "Navy Surveillance" 1600
-	system "Muhlifain"
+	system Muhlifain
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 3500
 		fleet "Small Southern Pirates" 6000
 		fleet "Small Republic" 3000
 		fleet "Large Republic" 4000
 		fleet "Navy Surveillance" 1600
-	system "Vindemiatrix"
+	system Vindemiatrix
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 3000
 		fleet "Small Southern Pirates" 2000
@@ -351,7 +351,7 @@ event "initial deployment 2"
 		fleet "Small Republic" 2000
 		fleet "Large Republic" 3000
 		fleet "Navy Surveillance" 1600
-	system "Sarin"
+	system Sarin
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 3000
 		fleet "Small Southern Pirates" 2000
@@ -359,7 +359,7 @@ event "initial deployment 2"
 		fleet "Small Republic" 8000
 		fleet "Large Republic" 15000
 		fleet "Navy Surveillance" 1600
-	system "Alioth"
+	system Alioth
 		fleet "Small Southern Merchants" 400
 		fleet "Large Northern Merchants" 600
 		fleet "Small Southern Pirates" 1200
@@ -367,49 +367,49 @@ event "initial deployment 2"
 		fleet "Small Republic" 3000
 		fleet "Large Republic" 4000
 		fleet "Navy Surveillance" 1600
-	system "Holeb"
+	system Holeb
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 3000
 		fleet "Small Southern Pirates" 5000
 		fleet "Small Republic" 2000
 		fleet "Large Republic" 3000
 		fleet "Navy Surveillance" 1600
-	system "Arcturus"
+	system Arcturus
 		fleet "Small Southern Merchants" 700
 		fleet "Large Southern Merchants" 3000
 		fleet "Small Southern Pirates" 4000
 		fleet "Small Republic" 2000
 		fleet "Large Republic" 3000
 		fleet "Navy Surveillance" 1600
-	system "Rutilicus"
+	system Rutilicus
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 2000
 		fleet "Small Southern Pirates" 8000
 		fleet "Small Republic" 1000
 		fleet "Large Republic" 2000
 		fleet "Navy Surveillance" 1600
-	system "Alphecca"
+	system Alphecca
 		fleet "Small Southern Merchants" 2000
 		fleet "Large Northern Merchants" 3500
 		fleet "Small Southern Pirates" 3000
 		fleet "Small Republic" 3000
 		fleet "Large Republic" 4000
 		fleet "Navy Surveillance" 1600
-	system "Boral"
+	system Boral
 		fleet "Small Southern Merchants" 3000
 		fleet "Large Northern Merchants" 8000
 		fleet "Small Southern Pirates" 1500
 		fleet "Small Republic" 7000
 		fleet "Large Republic" 12000
 		fleet "Navy Surveillance" 1600
-	system "Cebalrai"
+	system Cebalrai
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 2000
 		fleet "Small Southern Pirates" 4000
 		fleet "Small Republic" 1000
 		fleet "Large Republic" 2000
 		fleet "Navy Surveillance" 1600
-	system "Rasalhague"
+	system Rasalhague
 		fleet "Small Southern Merchants" 1500
 		fleet "Large Southern Merchants" 2000
 		fleet "Small Southern Pirates" 4000
@@ -420,32 +420,32 @@ event "initial deployment 2"
 
 event "initial deployment 3"
 	date 29 8 3014
-	system "Zubenelgenubi"
+	system Zubenelgenubi
 		fleet "Small Southern Merchants" 500
 		fleet "Large Southern Merchants" 900
 		fleet "Small Free Worlds" 800
 		fleet "Large Free Worlds" 1000
 		fleet "Small Southern Pirates" 5000
 		fleet "Large Southern Pirates" 8000
-	system "Unukalhai"
+	system Unukalhai
 		fleet "Small Southern Merchants" 900
 		fleet "Large Southern Merchants" 3000
 		fleet "Small Southern Pirates" 3000
 		fleet "Small Free Worlds" 3000
 		fleet "Large Free Worlds" 6000
-	system "Sabik"
+	system Sabik
 		fleet "Small Southern Merchants" 400
 		fleet "Large Southern Merchants" 600
 		fleet "Small Free Worlds" 1000
 		fleet "Large Free Worlds" 1600
-	system "Aldhibain"
+	system Aldhibain
 		fleet "Small Southern Merchants" 400
 		fleet "Large Southern Merchants" 500
 		fleet "Small Free Worlds" 600
 		fleet "Large Free Worlds" 700
 		fleet "Small Southern Pirates" 1400
 		fleet "Large Southern Pirates" 3000
-	system "Kornephoros"
+	system Kornephoros
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 700
 		fleet "Small Southern Pirates" 5000
@@ -453,28 +453,28 @@ event "initial deployment 3"
 		fleet "Large Free Worlds" 2000
 		fleet "Human Miners" 3000
 	
-	system "Wei"
+	system Wei
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 2500
 		fleet "Small Southern Pirates" 6000
 		fleet "Small Republic" 800
 		fleet "Large Republic" 700
 		fleet "Navy Surveillance" 1200
-	system "Seginus"
+	system Seginus
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 2700
 		fleet "Small Southern Pirates" 8000
 		fleet "Small Republic" 1200
 		fleet "Large Republic" 1400
 		fleet "Navy Surveillance" 1200
-	system "Alnasl"
+	system Alnasl
 		fleet "Small Southern Merchants" 1300
 		fleet "Large Southern Merchants" 2500
 		fleet "Small Southern Pirates" 6000
 		fleet "Small Republic" 900
 		fleet "Large Republic" 1100
 		fleet "Navy Surveillance" 1200
-	system "Eber"
+	system Eber
 		fleet "Small Southern Merchants" 1900
 		fleet "Large Southern Merchants" 2900
 		fleet "Small Southern Pirates" 3000
@@ -656,9 +656,9 @@ event "southern carriers 4"
 
 event "initial deployment 4"
 	date 17 9 3014
-	planet "Geminus"
+	planet Geminus
 		"required reputation" 10
-	system "Sargas"
+	system Sargas
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 2500
 		fleet "Small Southern Pirates" 3000
@@ -666,7 +666,7 @@ event "initial deployment 4"
 		fleet "Small Free Worlds" 1000
 		fleet "Large Free Worlds" 1500
 		fleet "Navy Surveillance" 800
-	system "Dschubba"
+	system Dschubba
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 2600
 		fleet "Small Southern Pirates" 3000
@@ -674,7 +674,7 @@ event "initial deployment 4"
 		fleet "Small Free Worlds" 2000
 		fleet "Large Free Worlds" 3000
 		fleet "Navy Surveillance" 800
-	system "Lesath"
+	system Lesath
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 1600
 		fleet "Small Southern Pirates" 3000
@@ -682,28 +682,28 @@ event "initial deployment 4"
 		fleet "Small Free Worlds" 800
 		fleet "Large Free Worlds" 1100
 		fleet "Navy Surveillance" 800
-	system "Atria"
+	system Atria
 		fleet "Small Southern Merchants" 700
 		fleet "Large Southern Merchants" 2600
 		fleet "Small Southern Pirates" 5000
 		fleet "Large Southern Pirates" 8000
 		fleet "Small Free Worlds" 1000
 		fleet "Large Free Worlds" 2100
-	system "Alniyat"
+	system Alniyat
 		fleet "Small Southern Merchants" 500
 		fleet "Large Southern Merchants" 600
 		fleet "Small Southern Pirates" 2000
 		fleet "Large Southern Pirates" 4000
 		fleet "Small Free Worlds" 1500
 		fleet "Large Free Worlds" 4000
-	system "Han"
+	system Han
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 4000
 		fleet "Small Southern Pirates" 2000
 		fleet "Large Southern Pirates" 9000
 		fleet "Small Free Worlds" 3000
 		fleet "Large Free Worlds" 8000
-	system "Pherkad"
+	system Pherkad
 		fleet "Small Southern Merchants" 500
 		fleet "Large Southern Merchants" 700
 		fleet "Small Free Worlds" 900
@@ -731,7 +731,7 @@ event "initial deployment 4"
 		fleet "Small Free Worlds" 3000
 		fleet "Large Free Worlds" 5000
 	
-	system "Rastaban"
+	system Rastaban
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 1900
 		fleet "Small Southern Pirates" 4000
@@ -739,13 +739,13 @@ event "initial deployment 4"
 		fleet "Small Republic" 900
 		fleet "Large Republic" 700
 		fleet "Navy Surveillance" 1200
-	system "Sabik"
+	system Sabik
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 800
 		fleet "Small Free Worlds" 800
 		fleet "Large Free Worlds" 1200
 		fleet "Navy Surveillance" 800
-	system "Aldhibain"
+	system Aldhibain
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 800
 		fleet "Small Free Worlds" 600
@@ -753,7 +753,7 @@ event "initial deployment 4"
 		fleet "Small Southern Pirates" 1400
 		fleet "Large Southern Pirates" 3000
 		fleet "Navy Surveillance" 800
-	system "Kornephoros"
+	system Kornephoros
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 1000
 		fleet "Small Southern Pirates" 5000
@@ -765,14 +765,14 @@ event "initial deployment 4"
 
 
 event "capture of Kornephoros"
-	system "Kornephoros"
-		government "Republic"
+	system Kornephoros
+		government Republic
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 1400
 		fleet "Small Republic" 300
 		fleet "Large Republic" 500
 		fleet "Navy Surveillance" 800
-	system "Sabik"
+	system Sabik
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 1000
 		fleet "Small Free Worlds" 400
@@ -787,7 +787,7 @@ event "capture of Kornephoros"
 
 
 event "start of hostilities"
-	government "Republic"
+	government Republic
 		"attitude toward"
 			"Free Worlds" -.2
 	government "Free Worlds"
@@ -797,13 +797,13 @@ event "start of hostilities"
 
 
 event "joined the free worlds"
-	government "Escort"
+	government Escort
 		swizzle 2
 
 
 
 event "temporary ceasefire"
-	government "Republic"
+	government Republic
 		"attitude toward"
 			"Free Worlds" 0
 	government "Free Worlds"
@@ -813,12 +813,12 @@ event "temporary ceasefire"
 
 
 event "recapture of Kornephoros"
-	system "Aldhibain"
+	system Aldhibain
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 800
 		fleet "Small Free Worlds" 600
 		fleet "Large Free Worlds" 600
-	system "Kornephoros"
+	system Kornephoros
 		government "Free Worlds"
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 1000
@@ -915,14 +915,14 @@ event "oathkeepers founded"
 
 
 event "Tarazed neutrality"
-	system "Tarazed"
-		government "Neutral"
-	system "Dabih"
-		government "Neutral"
-	system "Albireo"
-		government "Neutral"
-	system "Girtab"
-		government "Neutral"
+	system Tarazed
+		government Neutral
+	system Dabih
+		government Neutral
+	system Albireo
+		government Neutral
+	system Girtab
+		government Neutral
 
 
 
@@ -953,7 +953,7 @@ event "fw conservatory founded"
 
 event "Thule becomes independent"
 	system Men
-		government "Independent"
+		government Independent
 		fleet "Small Independent" 400
 		fleet "Large Independent" 600
 		fleet "Small Southern Merchants" 2000
@@ -983,7 +983,7 @@ event "fw suppressed Bloodsea"
 
 event "fw abandoned Bloodsea"
 	system Antares
-		government "Pirate"
+		government Pirate
 		fleet "Small Southern Pirates" 1000
 		fleet "Large Southern Pirates" 2000
 		fleet "Large Militia" 5000
@@ -1002,7 +1002,7 @@ event "fw suppressed Greenrock"
 
 event "fw abandoned Greenrock"
 	system Shaula
-		government "Pirate"
+		government Pirate
 		fleet "Small Southern Pirates" 500
 		fleet "Large Southern Pirates" 800
 		fleet "Small Core Pirates" 4000
@@ -1020,7 +1020,7 @@ event "flamethrower available"
 
 
 event "navy occupying the south"
-	system "Rastaban"
+	system Rastaban
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 2400
 		fleet "Small Republic" 500
@@ -1128,7 +1128,7 @@ event "navy using mark ii ships"
 
 
 fleet "gunboat only"
-	government "Republic"
+	government Republic
 	names "republic small"
 	cargo 0
 	personality
@@ -1170,7 +1170,7 @@ event "fw southern expansion"
 		fleet "Small Southern Pirates" 3000
 		fleet "Large Southern Pirates" 7000
 		fleet "Navy Surveillance" 5000
-	system "Rastaban"
+	system Rastaban
 		government "Free Worlds"
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 2400
@@ -1290,12 +1290,12 @@ mission "FW Clink Prison Closes"
 
 event "alphas capture Poisonwood"
 	system Graffias
-		government "Pirate"
+		government Pirate
 		fleet "Small Free Worlds" 10000
 
 event "liberation of Poisonwood"
 	system Graffias
-		government "Neutral"
+		government Neutral
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 4000
 		fleet "Small Southern Pirates" 6000
@@ -1305,7 +1305,7 @@ event "liberation of Poisonwood"
 
 event "Poisonwood reverts to Republic"
 	system Graffias
-		government "Republic"
+		government Republic
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 4000
 		fleet "Small Southern Pirates" 4000
@@ -1374,7 +1374,7 @@ event "battle for bloodsea"
 
 event "bloodsea independent"
 	system Antares
-		government "Independent"
+		government Independent
 		fleet "Small Independent" 800
 		fleet "Large Independent" 1500
 		fleet "Small Southern Merchants" 2000
@@ -1405,38 +1405,38 @@ event "albatross joins free worlds"
 
 
 event "fw expanded and cut"
-	system "Rasalhague"
+	system Rasalhague
 		government "Free Worlds"
 	system "Zeta Aquilae"
 		government "Free Worlds"
-	system "Ascella"
+	system Ascella
 		government "Free Worlds"
-	system "Peacock"
+	system Peacock
 		government "Free Worlds"
 	system "Kaus Australis"
 		government "Free Worlds"
 	system "Delta Sagittarii"
-		government "Republic"
+		government Republic
 		fleet "Small Southern Merchants" 2000
 		fleet "Large Southern Merchants" 6000
 		fleet "Small Republic" 500
 		fleet "Large Republic" 700
 		fleet "Large Free Worlds" 3000
-	system "Rastaban"
-		government "Republic"
+	system Rastaban
+		government Republic
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 4000
 		fleet "Small Republic" 700
 		fleet "Large Republic" 900
 		fleet "Large Free Worlds" 2000
-	system "Girtab"
-		government "Republic"
+	system Girtab
+		government Republic
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 3000
 		fleet "Small Republic" 900
 		fleet "Large Republic" 1200
 		fleet "Large Free Worlds" 1800
-	system "Lesath"
+	system Lesath
 		fleet "Small Southern Merchants" 6000
 		fleet "Large Southern Merchants" 9000
 		fleet "Small Republic" 1000
@@ -1551,7 +1551,7 @@ event "navy out of rastaban"
 		fleet "Large Southern Pirates" 7000
 		fleet "Navy Surveillance" 2000
 	system Girtab
-		government "Neutral"
+		government Neutral
 		fleet "Small Southern Merchants" 900
 		fleet "Large Southern Merchants" 2000
 		fleet "Small Free Worlds" 1000
@@ -1641,9 +1641,9 @@ event "pug invasion"
 		fleet "Large Southern Merchants" 6000
 		fleet "Small Pug" 5000
 		fleet "Large Pug" 9000
-	planet "Rand"
+	planet Rand
 		security 0
-	planet "Oblivion"
+	planet Oblivion
 		security 0
 
 
@@ -1687,11 +1687,11 @@ event "pug invasion 2"
 		fleet "Small Pug" 3000
 		fleet "Large Pug" 7000
 		fleet "Human Miners" 1600
-	planet "Silver"
+	planet Silver
 		security 0
-	planet "Shiver"
+	planet Shiver
 		security 0
-	planet "Millrace"
+	planet Millrace
 		security 0
 
 
@@ -1718,9 +1718,9 @@ event "pug invasion 3"
 		fleet "Large Core Merchants" 3200
 		fleet "Small Pug" 1200
 		fleet "Large Pug" 2500
-	planet "Maker"
+	planet Maker
 		security 0
-	planet "Furnace"
+	planet Furnace
 		security 0
 
 
@@ -1754,7 +1754,7 @@ event "pug invasion 4"
 		fleet "Small Pug" 700
 		fleet "Large Pug" 1000
 		fleet "Human Miners" 2000
-	planet "Reunion"
+	planet Reunion
 		security 0
 	planet "Kraken Station"
 		security 0
@@ -1808,14 +1808,14 @@ event "reconnected delta capricorni"
 
 
 event "battle for altair"
-	system "Altair"
+	system Altair
 		fleet "Small Core Merchants" 1500
 
 
 
 event "liberation of altair"
-	system "Altair"
-		government "Republic"
+	system Altair
+		government Republic
 		fleet "Small Core Merchants" 1000
 		fleet "Large Core Merchants" 2000
 		fleet "Small Pug" 2000
@@ -1825,7 +1825,7 @@ event "liberation of altair"
 
 event "reconnected altair"
 	link Altair Sol
-	system "Altair"
+	system Altair
 		government Republic
 		fleet "Small Core Merchants" 800
 		fleet "Large Core Merchants" 1200
@@ -1897,7 +1897,7 @@ event "pug flee"
 		object
 			sprite star/g5
 			period 10
-		object "Pugglemug"
+		object Pugglemug
 			sprite planet/ocean2
 			distance 317.56
 			period 90.543791
@@ -1905,7 +1905,7 @@ event "pug flee"
 				sprite planet/dust3
 				distance 159
 				period 16.370052
-		object "Pugglequat"
+		object Pugglequat
 			sprite planet/desert3
 			distance 966.8
 			period 480.9777
@@ -1961,21 +1961,21 @@ event "pug territory liberated"
 		fleet "Large Republic" 900 
 		fleet "Small Syndicate" 1200
 		fleet "Large Syndicate" 2000
-	planet "Rand"
+	planet Rand
 		security 0.05
-	planet "Oblivion"
+	planet Oblivion
 		security 0.05
-	planet "Silver"
+	planet Silver
 		security 0.1
-	planet "Shiver"
+	planet Shiver
 		security 0.1
-	planet "Millrace"
+	planet Millrace
 		security 0.2
-	planet "Maker"
+	planet Maker
 		security 0.4
-	planet "Furnace"
+	planet Furnace
 		security 0.1
-	planet "Reunion"
+	planet Reunion
 		security 0.3
 	planet "Kraken Station"
 		security 0.3
@@ -2055,10 +2055,10 @@ event "navy done with algenib"
 event "fwc southern battle"
 	system "Delta Sagittarii"
 		fleet "Large Free Worlds" 4000
-	system "Rastaban"
+	system Rastaban
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 4000
-	system "Girtab"
+	system Girtab
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 3000
 
@@ -2074,7 +2074,7 @@ event "fwc southern liberation"
 		fleet "Small Southern Pirates" 3000
 		fleet "Large Southern Pirates" 7000
 		fleet "Large Republic" 3000
-	system "Rastaban"
+	system Rastaban
 		government "Free Worlds"
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 2400
@@ -2084,7 +2084,7 @@ event "fwc southern liberation"
 		fleet "Large Southern Pirates" 7000
 		fleet "Large Republic" 3000
 	system Girtab
-		government "Neutral"
+		government Neutral
 		fleet "Small Southern Merchants" 900
 		fleet "Large Southern Merchants" 2000
 		fleet "Small Free Worlds" 1000
@@ -2131,14 +2131,14 @@ event "fwc capture kaus borealis"
 
 
 event "fwc attack cebalrai"
-	system "Cebalrai"
+	system Cebalrai
 		fleet "Small Southern Merchants" 5000
 		fleet "Large Southern Merchants" 6000
 
 
 
 event "fwc capture cebalrai"
-	system "Cebalrai"
+	system Cebalrai
 		government "Free Worlds"
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 1500
@@ -2161,13 +2161,13 @@ event "fwc solace has nukes"
 
 
 event "fwc defend cebalrai"
-	system "Cebalrai"
+	system Cebalrai
 		fleet "Large Free Worlds" 6000
 
 
 
 event "fwc defended cebalrai"
-	system "Cebalrai"
+	system Cebalrai
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 1500
 		fleet "Small Free Worlds" 500
@@ -2237,7 +2237,7 @@ event "fwc defended cebalrai"
 
 
 event "fwc attack menkent"
-	system "Menkent"
+	system Menkent
 		fleet "Small Southern Merchants" 5000
 
 
@@ -2257,7 +2257,7 @@ event "fwc capture menkent"
 
 
 event "fwc attack vega"
-	system "Vega"
+	system Vega
 		fleet "Small Southern Merchants" 50000
 
 
@@ -2309,7 +2309,7 @@ event "fwc pug invasion"
 		fleet "Large Northern Merchants" 3000
 		fleet "Small Pug" 700
 		fleet "Large Pug" 900
-	system "Vega"
+	system Vega
 		government "Free Worlds"
 	system "Delta Capricorni"
 		government Pug
@@ -2330,21 +2330,21 @@ event "fwc pug invasion"
 		fleet "Small Pug" 3000
 		fleet "Large Pug" 7000
 		fleet "Human Miners" 1600
-	planet "Rand"
+	planet Rand
 		security 0
-	planet "Oblivion"
+	planet Oblivion
 		security 0
-	planet "Silver"
+	planet Silver
 		security 0
-	planet "Shiver"
+	planet Shiver
 		security 0
-	planet "Millrace"
+	planet Millrace
 		security 0
-	planet "Maker"
+	planet Maker
 		security 0
-	planet "Furnace"
+	planet Furnace
 		security 0
-	planet "Reunion"
+	planet Reunion
 		security 0
 	planet "Kraken Station"
 		security 0
@@ -2362,15 +2362,15 @@ event "fwc pug peaceful"
 event "fwc navy retakes cebalrai"
 	unvisit Cebalrai
 	unvisit Menkent
-	system "Cebalrai"
-		government "Republic"
+	system Cebalrai
+		government Republic
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 1500
 		fleet "Small Republic" 500
 		fleet "Large Republic" 600
 		fleet "Large Free Worlds" 5000
 	system Menkent
-		government "Republic"
+		government Republic
 		fleet "Small Southern Merchants" 700
 		fleet "Large Southern Merchants" 1900
 		fleet "Small Republic" 300
@@ -2382,7 +2382,7 @@ event "fwc navy retakes cebalrai"
 
 event "fwc peace with the navy"
 	"reputation: Republic" = 1
-	government "Republic"
+	government Republic
 		"attitude toward"
 			"Free Worlds" 0
 	government "Free Worlds"
@@ -2430,7 +2430,7 @@ event "fwc battle for rasalhague"
 	link Rasalhague Cebalrai
 	system Rasalhague
 		fleet "Small Southern Merchants" 10000
-	government "Pug"
+	government Pug
 		"attitude toward"
 			"Free Worlds" -.01
 			"Republic" -.01
@@ -2491,14 +2491,14 @@ event "fwc reconnect zeta aquilae"
 
 event "fwc liberation of vega"
 	system Vega
-		government "Republic"
+		government Republic
 
 
 
 event "fwc reconnect vega"
 	link Sol Vega
 	system Vega
-		government "Republic"
+		government Republic
 		fleet "Small Southern Merchants" 1500
 		fleet "Large Southern Merchants" 2000
 		fleet "Small Republic" 500
@@ -2526,21 +2526,21 @@ event "fwc pug defeated"
 		fleet "Large Syndicate" 2000
 	system Nocte
 		government Republic
-	planet "Rand"
+	planet Rand
 		security 0.05
-	planet "Oblivion"
+	planet Oblivion
 		security 0.05
-	planet "Silver"
+	planet Silver
 		security 0.1
-	planet "Shiver"
+	planet Shiver
 		security 0.1
-	planet "Millrace"
+	planet Millrace
 		security 0.2
-	planet "Maker"
+	planet Maker
 		security 0.4
-	planet "Furnace"
+	planet Furnace
 		security 0.1
-	planet "Reunion"
+	planet Reunion
 		security 0.3
 	planet "Kraken Station"
 		security 0.3

--- a/data/events.txt
+++ b/data/events.txt
@@ -1342,39 +1342,49 @@ event "fw southern expansion"
 
 event "fw occupying the north"
 	system Alioth
-		fleet "Small Southern Merchants" 400
-		fleet "Large Southern Merchants" 600
-		fleet "Small Free Worlds" 500
-		fleet "Large Free Worlds" 800
-		fleet "Small Republic" 5000
-		fleet "Large Republic" 6000
-		fleet "Navy Surveillance" 4000
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Free Worlds" 500
+		add fleet "Large Free Worlds" 800
+		add fleet "Small Republic" 5000
+		add fleet "Large Republic" 6000
+		add fleet "Navy Surveillance" 4000
 	system Alphecca
-		fleet "Small Southern Merchants" 2000
-		fleet "Large Southern Merchants" 3500
-		fleet "Small Free Worlds" 1200
-		fleet "Large Free Worlds" 2000
-		fleet "Navy Surveillance" 6000
+		remove fleet "Small Southern Pirates"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Free Worlds" 1200
+		add fleet "Large Free Worlds" 2000
+		add fleet "Navy Surveillance" 6000
 	system Boral
-		fleet "Small Southern Merchants" 3000
-		fleet "Large Southern Merchants" 8000
-		fleet "Small Free Worlds" 1500
-		fleet "Large Free Worlds" 3800
-		fleet "Human Miners" 2000
+		remove fleet "Small Southern Pirates"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Free Worlds" 1500
+		add fleet "Large Free Worlds" 3800
 	system Seginus
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 2700
-		fleet "Small Free Worlds" 700
-		fleet "Large Free Worlds" 1100
-		fleet "Small Republic" 5000
-		fleet "Large Republic" 6000
-		fleet "Navy Surveillance" 4000
+		remove fleet "Small Southern Pirates"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Free Worlds" 700
+		add fleet "Large Free Worlds" 1100
+		add fleet "Small Republic" 5000
+		add fleet "Large Republic" 6000
+		add fleet "Navy Surveillance" 4000
 	system Wei
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 2500
-		fleet "Small Free Worlds" 800
-		fleet "Large Free Worlds" 1000
-		fleet "Navy Surveillance" 4000
+		remove fleet "Small Southern Pirates"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Free Worlds" 800
+		add fleet "Large Free Worlds" 1000
+		add fleet "Navy Surveillance" 4000
 
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -1062,6 +1062,12 @@ event "fw conservatory founded"
 
 
 
+event "battle for Thule"
+	system Men
+		fleet "Small Southern Pirates" 10000
+
+
+
 event "Thule becomes independent"
 	system Men
 		government Independent
@@ -1097,7 +1103,7 @@ event "fw abandoned Bloodsea"
 		government Pirate
 		fleet "Small Southern Pirates" 1000
 		fleet "Large Southern Pirates" 2000
-		fleet "Large Militia" 5000
+		fleet "Large Free Worlds" 5000
 
 
 
@@ -1120,7 +1126,7 @@ event "fw abandoned Greenrock"
 		fleet "Large Core Pirates" 7000
 		fleet "Small Northern Pirates" 5000
 		fleet "Large Northern Pirates" 9000
-		fleet "Large Militia" 9000
+		fleet "Large Free Worlds" 9000
 
 
 
@@ -1132,27 +1138,43 @@ event "flamethrower available"
 
 event "navy occupying the south"
 	system Rastaban
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 2400
-		fleet "Small Republic" 500
-		fleet "Large Republic" 700
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Southern Merchants" 1200
+		add fleet "Large Southern Merchants" 2400
+		add fleet "Small Republic" 1125
 	system Girtab
-		fleet "Small Southern Merchants" 900
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Republic" 500
-		fleet "Large Republic" 700
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 900
+		add fleet "Large Southern Merchants" 2000
+		add fleet "Small Republic" 500
+		add fleet "Large Republic" 700
 	system Albaldah
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 1200
-		fleet "Small Republic" 500
-		fleet "Large Republic" 700
-		fleet "Human Miners" 3000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 1000
+		add fleet "Large Southern Merchants" 1200
+		add fleet "Small Republic" 500
+		add fleet "Large Republic" 700
 	system "Delta Sagittarii"
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Republic" 500
-		fleet "Large Republic" 700
-		fleet "Human Miners" 3000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Militia"
+		remove fleet "Small Southern Pirates"
+		add fleet "Small Southern Merchants" 1200
+		add fleet "Large Southern Merchants" 4000
+		add fleet "Small Republic" 500
+		add fleet "Large Republic" 700
 
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -1635,16 +1635,6 @@ event "fw at war with Syndicate"
 			"Pirate" -.4
 			"Korath" -.5
 		bribe 0
-	system Rutilicus
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2000
-		fleet "Human Miners" 3000
-	system Cebalrai
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2000
-	system Holeb
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 3000
 
 
 
@@ -1683,24 +1673,6 @@ event "fw armistice"
 		"required reputation" 70
 	planet Mainsail
 		"required reputation" 40
-	system Rutilicus
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Southern Pirates" 8000
-		fleet "Small Republic" 1000
-		fleet "Human Miners" 3000
-	system Cebalrai
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Southern Pirates" 4000
-		fleet "Small Republic" 1000
-	system Holeb
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 3000
-		fleet "Small Southern Pirates" 5000
-		fleet "Small Republic" 2000
-		fleet "Large Republic" 3000
-		fleet "Navy Surveillance" 1600
 
 
 
@@ -2216,50 +2188,55 @@ event "fwc southern battle"
 	system "Delta Sagittarii"
 		fleet "Large Free Worlds" 4000
 	system Rastaban
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 4000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Large Free Worlds"
 	system Girtab
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 3000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Large Free Worlds"
 
 
 
 event "fwc southern liberation"
 	system "Delta Sagittarii"
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Free Worlds" 600
-		fleet "Large Free Worlds" 900
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Large Republic" 3000
-		fleet "Human Miners" 4000
+		add fleet "Small Southern Merchants" 1200
+		add fleet "Large Southern Merchants" 4000
+		add fleet "Small Free Worlds" 600
+		add fleet "Large Free Worlds" 1161
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 7000
+		add fleet "Large Republic" 3000
+		add fleet "Human Miners" 4000
 	system Rastaban
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 2400
-		fleet "Small Free Worlds" 500
-		fleet "Large Free Worlds" 700
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Large Republic" 3000
+		remove fleet "Small Southern Merchants"
+		add fleet "Small Southern Merchants" 1200
+		add fleet "Large Southern Merchants" 6000
+		add fleet "Small Free Worlds" 500
+		add fleet "Large Free Worlds" 700
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 7000
+		add fleet "Large Republic" 3000
 	system Girtab
 		government Neutral
-		fleet "Small Southern Merchants" 900
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Free Worlds" 1000
-		fleet "Large Free Worlds" 1700
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
+		add fleet "Small Southern Merchants" 9000
+		add fleet "Large Southern Merchants" 6000
+		add fleet "Small Free Worlds" 1000
+		add fleet "Large Free Worlds" 1700
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 7000
 	system Lesath
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 1600
-		fleet "Small Free Worlds" 800
-		fleet "Large Free Worlds" 1100
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 5000
-		fleet "Navy Surveillance" 4000
+		remove fleet "Large Free Worlds"
+		remove fleet "Large Free Worlds"
+		add fleet "Small Southern Merchants" 923
+		add fleet "Large Southern Merchants" 1945
+		add fleet "Small Free Worlds" 800
+		add fleet "Large Free Worlds" 1100
+		add fleet "Small Southern Pirates" 2000
+		add fleet "Large Southern Pirates" 5000
+		add fleet "Navy Surveillance" 4000
 
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -36,11 +36,11 @@ event "war begins"
 		government "Free Worlds"
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
 		add fleet "Small Free Worlds" 600
 		add fleet "Large Free Worlds" 1300
-		add fleet "Small Southern Merchants" 600
-		add fleet "Large Southern Merchants" 1400
-		add fleet "Human Miners" 10000
+		"set period" fleet "Small Southern Merchants" 600
+		"set period" fleet "Large Southern Merchants" 1400
 	system Spica
 		government "Free Worlds"
 	system Minkar
@@ -96,40 +96,30 @@ event "war begins"
 	system "Kappa Centauri"
 		government "Free Worlds"
 	system Castor
-		remove fleet "Small Northern Merchants"
-		remove fleet "Large Northern Merchants"
-		add fleet "Small Northern Merchants" 800
-		add fleet "Large Northern Merchants" 1100
-		add fleet "Small Republic" 4000
-		add fleet "Large Republic" 2000
+		"set period" fleet "Small Northern Merchants" 800
+		"set period" fleet "Large Northern Merchants" 1100
+		"set period" fleet "Small Republic" 800
+		"set period" fleet "Large Republic" 400
 	system Pollux
-		remove fleet "Small Northern Merchants"
-		remove fleet "Large Northern Merchants"
-		add fleet "Small Northern Merchants" 700
-		add fleet "Large Northern Merchants" 1100
-		add fleet "Small Republic" 2333
-		add fleet "Large Republic" 1636
+		"set period fleet "Small Northern Merchants" 700
+		"set period" fleet "Large Northern Merchants" 1100
+		"set period" fleet "Small Republic" 700
+		"set period" fleet "Large Republic" 900
 	system Vega
-		remove fleet "Small Northern Merchants"
-		remove fleet "Large Northern Merchants"
-		add fleet "Small Northern Merchants" 1000
-		add fleet "Large Northern Merchants" 4000
-		add fleet "Small Republic" 2057
-		add fleet "Large Republic" 1250
+		"set period" fleet "Small Northern Merchants" 1000
+		"set period" fleet "Large Northern Merchants" 4000
+		"set period" fleet "Small Republic" 900
+		"set period" fleet "Large Republic" 1000
 	system Denebola
-		remove fleet "Small Northern Merchants"
-		remove fleet "Large Northern Merchants"
-		add fleet "Small Northern Merchants" 1000
-		add fleet "Large Northern Merchants" 3000
-		add fleet "Small Republic" 2333
-		add fleet "Large Republic" 1636
+		"set period" fleet "Small Northern Merchants" 1000
+		"set period" fleet "Large Northern Merchants" 3000
+		"set period" fleet "Small Republic" 700
+		"set period" fleet "Large Republic" 900
 	system Merak
-		remove fleet "Small Northern Merchants"
-		remove fleet "Large Northern Merchants"
-		add fleet "Small Northern Merchants" 1500
-		add fleet "Large Northern Merchants" 4000
-		add fleet "Small Republic" 2444
-		add fleet "Large Republic" 1925
+		"set period" fleet "Small Northern Merchants" 1500
+		"set period" fleet "Large Northern Merchants" 4000
+		"set period" fleet "Small Republic" 1100
+		"set period" fleet "Large Republic" 1300
 	planet Geminus
 		description `Until recently, Geminus was home to the Republic Navy Yard, the largest shipyard in human space. Now, there is nothing left of the shipyard but a gaping crater in the ground, from the recent terrorist bombing.`
 		spaceport `Fortunately, the spaceport and residential areas survived the bombing, which was focused only on the Navy yard and happened early in the morning, when very few people were at work.`
@@ -166,31 +156,31 @@ event "initial deployment 1"
 		remove fleet "Large Militia"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 4800
-		add fleet "Large Southern Merchants" 3923
+		"set period" fleet "Small Southern Merchants" 1200
+		"set period" fleet "Large Southern Merchants" 1700
 		add fleet "Small Free Worlds" 800
 		add fleet "Large Free Worlds" 1500
 	system Minkar
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
 		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 3150
-		add fleet "Large Southern Merchants" 3000
+		"set period" fleet "Small Southern Merchants" 700
+		"set period" fleet "Large Southern Merchants" 1500
 		add fleet "Small Free Worlds" 700
 		add fleet "Large Free Worlds" 1200
 	system Mimosa
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
 		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 4800
-		add fleet "Large Southern Merchants" 4259
+		"set period" fleet "Small Southern Merchants" 1200
+		"set period" fleet "Large Southern Merchants" 2300
 		add fleet "Small Free Worlds" 1200
 		add fleet "Large Free Worlds" 1900
 	system Kraz
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		add fleet "Small Southern Merchants" 9000
-		add fleet "Large Southern Merchants" 8000
+		"set period" fleet "Small Southern Merchants" 900
+		"set period" fleet "Large Southern Merchants" 1600
 		add fleet "Small Free Worlds" 700
 		add fleet "Large Free Worlds" 900
 	system Acrux
@@ -198,109 +188,82 @@ event "initial deployment 1"
 		remove fleet "Large Militia"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 3000
-		add fleet "Large Southern Merchants" 4000
+		"set period" fleet "Small Southern Merchants" 500
+		"set period" fleet "Large Southern Merchants" 800
 		add fleet "Small Free Worlds" 700
 		add fleet "Large Free Worlds" 1100
 	
 	system "Tania Australis"
 		remove fleet "Small Northern Pirates"
 		remove fleet "Large Northern Pirates"
-		remove fleet "Small Northern Merchants"
-		remove fleet "Large Northern Merchants"
-		add fleet "Small Northern Merchants" 1400
-		add fleet "Large Northern Merchants" 2900
-		add fleet "Small Republic" 750
+		"set period" fleet "Small Northern Merchants" 1400
+		"set period" fleet "Large Northern Merchants" 2900
+		"set period" fleet "Small Republic" 600
 		add fleet "Large Republic" 400
 		add fleet "Navy Surveillance" 2000
 	planet Ingot
 		add description `Ingot is also now home to a burgeoning Navy base, although since the planet is so unlivable most of the troops are just living in ships in orbit.`
 	system Fala
-		remove fleet "Small Northern Merchants"
-		remove fleet "Large Northern Merchants"
-		remove fleet "Small Northern Pirates"
-		remove fleet "Large Northern Pirates"
-		remove fleet "Human Miners"
-		add fleet "Small Northern Merchants" 1900
-		add fleet "Large Northern Merchants" 3500
-		add fleet "Small Republic" 705
+		"set period" fleet "Small Northern Merchants" 1900
+		"set period" fleet "Large Northern Merchants" 3500
+		"set period" fleet "Small Republic" 600
 		add fleet "Large Republic" 400
-		add fleet "Small Northern Pirates" 4000
-		add fleet "Large Northern Pirates" 8000
+		"set period" fleet "Small Northern Pirates" 4000
+		"set period" fleet "Large Northern Pirates" 8000
 		add fleet "Navy Surveillance" 2000
-		add fleet "Human Miners" 3000
+		"set period" fleet "Human Miners" 3000
 	system Phecda
-		remove fleet "Small Northern Merchants"
 		remove fleet "Large Northern Merchants"
-		remove fleet "Small Southern Merchants"
 		remove fleet "Large Southern Merchants"
-		add fleet "Small Northern Merchants" 900
-		add fleet "Small Southern Merchants" 1100
-		add fleet "Small Republic" 1097
+		"set period" fleet "Small Northern Merchants" 900
+		"set period" fleet "Small Southern Merchants" 1100
+		"set period" fleet "Small Republic" 900
 		add fleet "Large Republic" 1100
 		add fleet "Navy Surveillance" 2000
-		add fleet "Human Miners" 3000
+		"set period" fleet "Human Miners" 3000
 	system Algorel
 		remove fleet "Small Militia"
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 800
-		add fleet "Large Southern Merchants" 1200
-		add fleet "Small Republic" 913
+		"set period" fleet "Small Southern Merchants" 800
+		"set period" fleet "Large Southern Merchants" 1200
+		"set period" fleet "Small Republic" 700
 		add fleet "Large Republic" 500
-		add fleet "Small Southern Pirates" 2500
-		add fleet "Large Southern Pirates" 8000
+		"set period" fleet "Small Southern Pirates" 2500
+		"set period" fleet "Large Southern Pirates" 8000
 		add fleet "Navy Surveillance" 2000
 	planet "New Wales"
 		add description `The Republic Navy has planted a base on New Wales: so far, just a densely packed cluster of prefabricated barracks and infirmary buildings on the outskirts of one of the mining colonies.`
 	system Porrima
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		add fleet "Small Southern Merchants" 1400
-		add fleet "Large Southern Merchants" 4000
-		add fleet "Small Republic" 1411
+		"set period" fleet "Small Southern Merchants" 1400
+		"set period" fleet "Large Southern Merchants" 4000
+		"set period" fleet "Small Republic" 1200
 		add fleet "Large Republic" 1800
-		add fleet "Small Southern Pirates" 9000
+		"set period" fleet "Small Southern Pirates" 9000
 		add fleet "Navy Surveillance" 2000
 	system Ipsing
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		add fleet "Small Southern Merchants" 2800
-		add fleet "Large Southern Merchants" 7000
+		"set period" fleet "Small Southern Merchants" 2800
+		"set period" fleet "Large Southern Merchants" 7000
 		add fleet "Small Republic" 2500
 		add fleet "Large Republic" 4000
-		add fleet "Small Southern Pirates" 5000
+		"set period" fleet "Small Southern Pirates" 5000
 		add fleet "Navy Surveillance" 2000
 	system Mizar
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		add fleet "Small Southern Merchants" 1400
-		add fleet "Large Southern Merchants" 4500
+		"set period" fleet "Small Southern Merchants" 1400
+		"set period" fleet "Large Southern Merchants" 4500
 		add fleet "Small Republic" 1000
 		add fleet "Large Republic" 1400
-		add fleet "Small Southern Pirates" 9000
+		"set period" fleet "Small Southern Pirates" 9000
 		add fleet "Navy Surveillance" 2000
 	system Muphrid
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		add fleet "Small Southern Merchants" 1200
-		add fleet "Large Southern Merchants" 4800
-		add fleet "Small Republic" 1410
+		"set period" fleet "Small Southern Merchants" 1200
+		"set period" fleet "Large Southern Merchants" 4800
+		"set period" fleet "Small Republic" 1100
 		add fleet "Large Republic" 1900
-		add fleet "Small Southern Pirates" 9000
+		"set period" fleet "Small Southern Pirates" 9000
 		add fleet "Navy Surveillance" 2000
 	system Menkent
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		add fleet "Small Southern Merchants" 700
-		add fleet "Large Southern Merchants" 1900
-		add fleet "Small Republic" 600
+		"set period" fleet "Small Southern Merchants" 700
+		"set period" fleet "Large Southern Merchants" 1900
+		"set period" fleet "Small Republic" 500
 		add fleet "Large Republic" 600
 		add fleet "Navy Surveillance" 2000
 	planet "New Austria"
@@ -317,83 +280,69 @@ event "initial deployment 2"
 	system Izar
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		add fleet "Small Southern Merchants" 1750
-		add fleet "Large Southern Merchants" 9000
+		"set period" fleet "Small Southern Merchants" 500
+		"set period" fleet "Large Southern Merchants" 1500
 		add fleet "Small Free Worlds" 700
 		add fleet "Large Free Worlds" 1000
 	system "Zeta Centauri"
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 5600
-		add fleet "Large Southern Merchants" 11333
+		"set period" fleet "Small Southern Merchants" 700
+		"set period" fleet "Large Southern Merchants" 1700
 		add fleet "Small Free Worlds" 1200
 		add fleet "Large Free Worlds" 2000
-		add fleet "Small Southern Pirates" 6000
-		add fleet "Large Southern Pirates" 9000
+		"set period" fleet "Small Southern Pirates" 6000
+		"set period" fleet "Large Southern Pirates" 9000
 	system Hadar
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		add fleet "Large Southern Merchants" 1500
+		"set period" fleet "Large Southern Merchants" 600
 		add fleet "Small Free Worlds" 600
 		add fleet "Large Free Worlds" 1100
 	system Alkaid
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 4800
-		add fleet "Large Southern Merchants" 20000
+		"set period" fleet "Small Southern Merchants" 1200
+		"set period" fleet "Large Southern Merchants" 4000
 		add fleet "Small Free Worlds" 6000
 		add fleet "Large Free Worlds" 10000
-		add fleet "Small Southern Pirates" 4000
-		add fleet "Large Southern Pirates" 8000
+		"set period" fleet "Small Southern Pirates" 4000
+		"set period" fleet "Large Southern Pirates" 8000
 	system Zubeneschamali
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Large Southern Merchants" 3000
+		"set period" fleet "Large Southern Merchants" 1000
 		add fleet "Small Free Worlds" 1400
 		add fleet "Large Free Worlds" 2400
-		add fleet "Small Southern Pirates" 4000
-		add fleet "Large Southern Pirates" 5000
+		"set period" fleet "Small Southern Pirates" 4000
+		"set period" fleet "Large Southern Pirates" 5000
 	system Kochab
 		remove fleet "Small Militia"
-		remove fleet "Small Southern Pirates"
-		add fleet "Small Southern Merchants" 18000
-		add fleet "Large Southern Merchants" 30000
+		"set period" fleet "Small Southern Merchants" 1800
+		"set period" fleet "Large Southern Merchants" 5000
 		add fleet "Small Free Worlds" 5000
-		add fleet "Small Southern Pirates" 6000
+		"set period" fleet "Small Southern Pirates" 6000
 	system Ildaria
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 9000
-		add fleet "Large Southern Merchants" 18000
+		"set period" fleet "Small Southern Merchants" 900
+		"set period" fleet "Large Southern Merchants" 1800
 		add fleet "Small Free Worlds" 2200
 		add fleet "Large Free Worlds" 3600
-		add fleet "Small Southern Pirates" 4000
-		add fleet "Large Southern Pirates" 7000
+		"set period" fleet "Small Southern Pirates" 4000
+		"set period" fleet "Large Southern Pirates" 7000
 	
 	system Mora
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		remove fleet "Human Miners"
-		add fleet "Small Southern Merchants" 2800
-		add fleet "Large Southern Merchants" 5000
-		add fleet "Small Southern Pirates" 3000
-		add fleet "Large Southern Pirates" 4000
-		add fleet "Small Republic" 1052
+		"set period" fleet "Small Southern Merchants" 2800
+		"set period" fleet "Large Southern Merchants" 5000
+		"set period" fleet "Small Southern Pirates" 3000
+		"set period" fleet "Large Southern Pirates" 4000
+		"set period" fleet "Small Republic" 1000
 		add fleet "Large Republic" 2000
 		add fleet "Navy Surveillance" 1600
-		add fleet "Human Miners" 4000
+		"set period" fleet "Human Miners" 4000
 	system "Delta Velorum"
-		add fleet "Small Republic" 1846
+		"set period" fleet "Small Republic" 1600
 		add fleet "Large Republic" 2400
 		add fleet "Navy Surveillance" 1600
 	system Turais
@@ -401,15 +350,13 @@ event "initial deployment 2"
 		add fleet "Large Republic" 1800
 		add fleet "Navy Surveillance" 1600
 	system Gacrux
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Pirates" 2000
-		add fleet "Large Southern Pirates" 4000
-		add fleet "Small Republic" 2307
+		"set period" fleet "Small Southern Pirates" 2000
+		"set period" fleet "Large Southern Pirates" 4000
+		"set period" fleet "Small Republic" 2000
 		add fleet "Large Republic" 3000
 		add fleet "Navy Surveillance" 1600
 	system "Cor Caroli"
-		add fleet "Small Republic" 1363
+		"set period" fleet "Small Republic" 1200
 		add fleet "Large Republic" 1800
 		add fleet "Navy Surveillance" 1600
 	system Muhlifain
@@ -471,114 +418,90 @@ event "initial deployment 3"
 	system Zubenelgenubi
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Large Southern Merchants" 2250
+		"set period" fleet "Large Southern Merchants" 900
 		add fleet "Small Free Worlds" 800
 		add fleet "Large Free Worlds" 1000
-		add fleet "Small Southern Pirates" 5000
-		add fleet "Large Southern Pirates" 8000
+		"set period" fleet "Small Southern Pirates" 5000
+		"set period" fleet "Large Southern Pirates" 8000
 	system Unukalhai
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		add fleet "Small Southern Merchants" 9000
-		add fleet "Large Southern Merchants" 12000
+		"set period" fleet "Small Southern Merchants" 900
+		"set period" fleet "Large Southern Merchants" 3000
 		add fleet "Small Free Worlds" 3000
 		add fleet "Large Free Worlds" 6000
 	system Sabik
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		add fleet "Large Southern Merchants" 1800
+		"set period" fleet "Large Southern Merchants" 600
 		add fleet "Small Free Worlds" 1000
 		add fleet "Large Free Worlds" 1600
 	system Aldhibain
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Large Southern Merchants" 3000
+		"set period" fleet "Large Southern Merchants" 500
 		add fleet "Small Free Worlds" 600
 		add fleet "Large Free Worlds" 700
-		add fleet "Small Southern Pirates" 1400
-		add fleet "Large Southern Pirates" 3000
+		"set period" fleet "Small Southern Pirates" 1400
+		"set period" fleet "Large Southern Pirates" 3000
 	system Kornephoros
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Pirates"
-		add fleet "Large Southern Merchants" 1680
-		add fleet "Small Southern Pirates" 5000
+		"set period" fleet "Large Southern Merchants" 700
+		"set period" fleet "Small Southern Pirates" 5000
 		add fleet "Small Free Worlds" 1000
 		add fleet "Large Free Worlds" 2000
 	
 	system Wei
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		add fleet "Small Southern Merchants" 800
-		add fleet "Large Southern Merchants" 2500
-		add fleet "Small Southern Pirates" 6000
+		"set period" fleet "Small Southern Merchants" 800
+		"set period" fleet "Large Southern Merchants" 2500
+		"set period" fleet "Small Southern Pirates" 6000
 		add fleet "Small Republic" 800
 		add fleet "Large Republic" 700
 		add fleet "Navy Surveillance" 1200
 	system Seginus
 		remove fleet "Small Militia"
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		add fleet "Small Southern Merchants" 1200
-		add fleet "Large Southern Merchants" 2700
-		add fleet "Small Southern Pirates" 8000
+		"set period" fleet "Small Southern Merchants" 1200
+		"set period" fleet "Large Southern Merchants" 2700
+		"set period" fleet "Small Southern Pirates" 8000
 		add fleet "Small Republic" 1200
 		add fleet "Large Republic" 1400
 		add fleet "Navy Surveillance" 1200
 	system Alnasl
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		add fleet "Small Southern Merchants" 1300
-		add fleet "Large Southern Merchants" 2500
-		add fleet "Small Southern Pirates" 6000
+		"set period" fleet "Small Southern Merchants" 1300
+		"set period" fleet "Large Southern Merchants" 2500
+		"set period" fleet "Small Southern Pirates" 6000
 		add fleet "Small Republic" 900
 		add fleet "Large Republic" 1100
 		add fleet "Navy Surveillance" 1200
 	system Eber
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		add fleet "Small Southern Merchants" 1900
-		add fleet "Large Southern Merchants" 2900
-		add fleet "Small Southern Pirates" 3000
+		"set period" fleet "Small Southern Merchants" 1900
+		"set period" fleet "Large Southern Merchants" 2900
+		"set period" fleet "Small Southern Pirates" 3000
 		add fleet "Small Republic" 1000
 		add fleet "Large Republic" 1500
 		add fleet "Navy Surveillance" 1200
 	system "Alpha Arae"
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 2100
-		add fleet "Large Southern Merchants" 8000
-		add fleet "Small Southern Pirates" 6000
-		add fleet "Large Southern Pirates" 13000
+		"set period" fleet "Small Southern Merchants" 2100
+		"set period" fleet "Large Southern Merchants" 8000
+		"set period" fleet "Small Southern Pirates" 6000
+		"set period" fleet "Large Southern Pirates" 13000
 		add fleet "Small Republic" 900
 		add fleet "Large Republic" 800
 		add fleet "Navy Surveillance" 1200
 	system "Kaus Borealis"
 		remove fleet "Small Militia"
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		add fleet "Small Southern Merchants" 900
-		add fleet "Large Southern Merchants" 4000
-		add fleet "Small Southern Pirates" 8000
+		"set period" fleet "Small Southern Merchants" 900
+		"set period" fleet "Large Southern Merchants" 4000
+		"set period" fleet "Small Southern Pirates" 8000
 		add fleet "Small Republic" 1100
 		add fleet "Large Republic" 800
 		add fleet "Navy Surveillance" 1200
@@ -747,135 +670,112 @@ event "initial deployment 4"
 	system Sargas
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 4200
-		add fleet "Large Southern Merchants" 15000
-		add fleet "Small Southern Pirates" 3000
-		add fleet "Large Southern Pirates" 5000
+		"set period" fleet "Small Southern Merchants" 600
+		"set period" fleet "Large Southern Merchants" 2500
+		"set period" fleet "Small Southern Pirates" 3000
+		"set period" fleet "Large Southern Pirates" 5000
 		add fleet "Small Free Worlds" 1000
 		add fleet "Large Free Worlds" 1500
 		add fleet "Navy Surveillance" 800
 	system Dschubba
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 4000
-		add fleet "Large Southern Merchants" 19500
-		add fleet "Small Southern Pirates" 3000
-		add fleet "Large Southern Pirates" 6000
+		"set period" fleet "Small Southern Merchants" 800
+		"set period" fleet "Large Southern Merchants" 2600
+		"set period" fleet "Small Southern Pirates" 3000
+		"set period" fleet "Large Southern Pirates" 6000
 		add fleet "Small Free Worlds" 2000
 		add fleet "Large Free Worlds" 3000
 		add fleet "Navy Surveillance" 800
 	system Lesath
 		remove fleet "Small Militia"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 4000
-		add fleet "Large Southern Merchants" 8000
-		add fleet "Small Southern Pirates" 3000
-		add fleet "Large Southern Pirates" 7000
+		"set period" fleet "Small Southern Merchants" 800
+		"set period" fleet "Large Southern Merchants" 1600
+		"set period" fleet "Small Southern Pirates" 3000
+		"set period" fleet "Large Southern Pirates" 7000
 		add fleet "Small Free Worlds" 800
 		add fleet "Large Free Worlds" 1100
 		add fleet "Navy Surveillance" 800
 	system Atria
 		remove fleet "Small Militia"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 2333
-		add fleet "Large Southern Merchants" 19500
-		add fleet "Small Southern Pirates" 5000
-		add fleet "Large Southern Pirates" 8000
+		"set period" fleet "Small Southern Merchants" 700
+		"set period" fleet "Large Southern Merchants" 2600
+		"set period" fleet "Small Southern Pirates" 5000
+		"set period" fleet "Large Southern Pirates" 8000
 		add fleet "Small Free Worlds" 1000
 		add fleet "Large Free Worlds" 2100
 	system Alniyat
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		add fleet "Large Southern Merchants" 4200
+		"set period" fleet "Large Southern Merchants" 600
 		add fleet "Small Free Worlds" 1500
 		add fleet "Large Free Worlds" 4000
 	system Han
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 4000
-		add fleet "Large Southern Merchants" 20000
-		add fleet "Small Southern Pirates" 2000
-		add fleet "Large Southern Pirates" 9000
+		"set period" fleet "Small Southern Merchants" 800
+		"set period" fleet "Large Southern Merchants" 4000
+		"set period" fleet "Small Southern Pirates" 2000
+		"set period" fleet "Large Southern Pirates" 9000
 		add fleet "Small Free Worlds" 3000
 		add fleet "Large Free Worlds" 8000
 	system Pherkad
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		add fleet "Large Southern Merchants" 2333
+		"set period" fleet "Large Southern Merchants" 700
 		add fleet "Small Free Worlds" 900
 		add fleet "Large Free Worlds" 1700
-		add fleet "Small Southern Pirates" 2000
-		add fleet "Large Southern Pirates" 5181
+		"set period" fleet "Small Southern Pirates" 1000
+		"set period" fleet "Large Southern Pirates" 1900
 	system "Beta Lupi"
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		add fleet "Small Southern Merchants" 4000
-		add fleet "Small Southern Pirates" 4125
-		add fleet "Large Southern Pirates" 4444
+		"set period" fleet "Small Southern Merchants" 800
+		"set period" fleet "Small Southern Pirates" 1100
+		"set period" fleet "Large Southern Pirates" 1600
 		add fleet "Small Free Worlds" 4000
 		add fleet "Large Free Worlds" 8000
 	system "Yed Prior"
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		add fleet "Large Southern Merchants" 3520
-		add fleet "Small Southern Pirates" 2000
-		add fleet "Large Southern Pirates" 6000
+		"set period" fleet "Large Southern Merchants" 1100
+		"set period" fleet "Small Southern Pirates" 1000
+		"set period" fleet "Large Southern Pirates" 2000
 		add fleet "Small Free Worlds" 5000
 		add fleet "Large Free Worlds" 8000
 	system "Kappa Centauri"
 		remove fleet "Small Militia"
-		add fleet "Small Southern Merchants" 9000
-		add fleet "Large Southern Merchants" 27000
-		add fleet "Small Southern Pirates" 8000
+		"set period" fleet "Small Southern Merchants" 900
+		"set period" fleet "Large Southern Merchants" 2700
+		"set period" fleet "Small Southern Pirates" 1600
 		add fleet "Large Southern Pirates" 2000
 		add fleet "Small Free Worlds" 3000
 		add fleet "Large Free Worlds" 5000
 	
 	system Rastaban
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 1000
-		add fleet "Large Southern Merchants" 1900
-		add fleet "Small Southern Pirates" 4000
-		add fleet "Large Southern Pirates" 8000
+		"set period" fleet "Small Southern Merchants" 1000
+		"set period" fleet "Large Southern Merchants" 1900
+		"set period" fleet "Small Southern Pirates" 4000
+		"set period" fleet "Large Southern Pirates" 8000
 		add fleet "Small Republic" 900
 		add fleet "Large Republic" 700
 		add fleet "Navy Surveillance" 1200
 	system Sabik
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		add fleet "Small Southern Merchants" 600
-		add fleet "Large Southern Merchants" 800
-		add fleet "Small Free Worlds" 4000
-		add fleet "Large Free Worlds" 4800
+		"set period" fleet "Small Southern Merchants" 600
+		"set period" fleet "Large Southern Merchants" 800
+		"set period" fleet "Small Free Worlds" 800
+		"set period" fleet "Large Free Worlds" 1200
 		add fleet "Navy Surveillance" 800
 	system Aldhibain
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		add fleet "Small Southern Merchants" 600
-		add fleet "Large Southern Merchants" 800
-		add fleet "Large Free Worlds" 4200
+		"set period" fleet "Small Southern Merchants" 600
+		"set period" fleet "Large Southern Merchants" 800
+		"set period" fleet "Large Free Worlds" 600
 		add fleet "Navy Surveillance" 800
 	system Kornephoros
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		add fleet "Small Southern Merchants" 800
-		add fleet "Large Southern Merchants" 1000
-		add fleet "Small Free Worlds" 9000
-		add fleet "Large Free Worlds" 11333
+		"set period" fleet "Small Southern Merchants" 800
+		"set period" fleet "Large Southern Merchants" 1000
+		"set period" fleet "Small Free Worlds" 900
+		"set period" fleet "Large Free Worlds" 1700
 		add fleet "Navy Surveillance" 800
 
 
@@ -884,23 +784,17 @@ event "capture of Kornephoros"
 	system Kornephoros
 		government Republic
 		remove fleet "Small Free Worlds"
-		remove fleet "Small Free Worlds"
 		remove fleet "Large Free Worlds"
-		remove fleet "Large Free Worlds"
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		add fleet "Small Southern Merchants" 1200
-		add fleet "Large Southern Merchants" 1400
+		"set period" fleet "Small Southern Merchants" 1200
+		"set period" fleet "Large Southern Merchants" 1400
 		add fleet "Small Republic" 300
 		add fleet "Large Republic" 500
 	system Sabik
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
 		remove fleet "Navy Surveillance"
-		add fleet "Small Southern Merchants" 800
-		add fleet "Large Southern Merchants" 1000
-		add fleet "Small Free Worlds" 800
-		add fleet "Large Free Worlds" 1200
+		"set period" fleet "Small Southern Merchants" 800
+		"set period" fleet "Large Southern Merchants" 1000
+		"set period" fleet "Small Free Worlds" 400
+		"set period" fleet "Large Free Worlds" 600
 	planet Clink
 		description `The mining outpost is swarming with Navy guards; they seem to have turned this moon into a temporary base of operations. The mine has been shut down, and no one is being allowed in or out of the mining outpost. It is not clear whether the miners are prisoners, or merely under a very tight watch.`
 		security 1
@@ -938,7 +832,12 @@ event "temporary ceasefire"
 
 event "prepare for battle of Kornephoros"
 	system "Kornephoros"
-		fleet "Small Free Worlds" 10000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Free Worlds" 10000
 
 
 
@@ -949,11 +848,11 @@ event "recapture of Kornephoros"
 		remove fleet "Navy Surveillance"
 	system Kornephoros
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 1000
-		fleet "Small Free Worlds" 900
-		fleet "Large Free Worlds" 1700
-		fleet "Human Miners" 3000
+		add fleet "Small Southern Merchants" 800
+		add fleet "Large Southern Merchants" 1000
+		"set period" "Small Free Worlds" 900
+		add fleet "Large Free Worlds" 1700
+		"set period" fleet "Human Miners" 3000
 	planet Clink
 		description `About a decade ago, a mining corporation from Zug planted a colony on Clink for harvesting some rare earth minerals that are present in this moon's crust due to its unusually high rate of asteroid impacts. The atmosphere here is too thin to breathe without a respirator, and because of the low gravity, the dust raised by the mining operations hangs perpetually in the air.`
 		description `The miners who work here are a tight-knit group, since most of them were part of the original colonization team. They are not particularly open to outsiders, and the facilities here are so rudimentary that they do not even stock fuel for visiting ships.`
@@ -1047,14 +946,12 @@ event "plasma turret available"
 
 event "fw conservatory founded"
 	system "Yed Prior"
-		remove fleet "Small Southern Pirates"
-		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 1333
-		add fleet "Large Southern Merchants" 2933
-		add fleet "Small Southern Pirates" 1200
-		add fleet "Large Southern Pirates" 2400
-		add fleet "Small Free Worlds" 1250
-		add fleet "Large Free Worlds" 1846
+		"set period" fleet "Small Southern Merchants" 500
+		"set period" fleet "Large Southern Merchants" 800
+		"set period" fleet "Small Southern Pirates" 1200
+		"set period" fleet "Large Southern Pirates" 2400
+		"set period" fleet "Small Free Worlds" 1000
+		"set period" fleet "Large Free Worlds" 1500
 	planet Winter
 		add attributes research
 		add description `	Winter is home to the Free Worlds Conservatory, a new university that is focused on making terraforming technology and expertise available at a reasonable price, as well as on ecological protection and renewal.`
@@ -1064,20 +961,23 @@ event "fw conservatory founded"
 
 event "battle for Thule"
 	system Men
-		fleet "Small Southern Pirates" 10000
+		remove fleet "Large Southern Pirates"
+		remove fleet "Small Northern Pirates"
+		remove fleet "Large Northern Pirates"
+		"set period" fleet "Small Southern Pirates" 10000
 
 
 
 event "Thule becomes independent"
 	system Men
 		government Independent
-		fleet "Small Independent" 400
-		fleet "Large Independent" 600
-		fleet "Small Southern Merchants" 2000
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Southern Pirates" 2500
-		fleet "Large Southern Pirates" 5000
-		fleet "Large Free Worlds" 1500
+		add fleet "Small Independent" 400
+		add fleet "Large Independent" 600
+		add fleet "Small Southern Merchants" 2000
+		add fleet "Large Southern Merchants" 4000
+		"set period" fleet "Small Southern Pirates" 2500
+		"set period" fleet "Large Southern Pirates" 5000
+		add fleet "Large Free Worlds" 1500
 	planet Thule
 		description `Thule is a mountainous world with a population of nearly a billion, settled in the early days of space exploration. When the colony was first established, the Earth government did not yet have the strength to control any system but its own, and when the Republic was formed, Thule did not join, and has repulsed all efforts to force them to do so.`
 		description `	Until recently, Thule was a well-known den of pirate activity, but the major tribal authorities have now forsworn piracy in the interest of keeping the Free Worlds from further meddling in their affairs. However, it is likely that all manner of illegal activity is still going on in secret here.`
@@ -1091,42 +991,50 @@ event "Thule becomes independent"
 event "fw suppressed Bloodsea"
 	system Antares
 		government "Free Worlds"
-		fleet "Small Free Worlds" 800
-		fleet "Large Free Worlds" 1600
-		fleet "Small Southern Pirates" 4000
-		fleet "Large Southern Pirates" 8000
+		remove fleet "Large Militia"
+		add fleet "Small Free Worlds" 800
+		add fleet "Large Free Worlds" 1600
+		"set period" fleet "Small Southern Pirates" 4000
+		"set period" fleet "Large Southern Pirates" 8000
 
 
 
 event "fw abandoned Bloodsea"
 	system Antares
 		government Pirate
-		fleet "Small Southern Pirates" 1000
-		fleet "Large Southern Pirates" 2000
-		fleet "Large Free Worlds" 5000
+		remove fleet "Small Free Worlds"
+		"set period" fleet "Small Southern Pirates" 1000
+		"set period" fleet "Large Southern Pirates" 2000
+		"set period" fleet "Large Free Worlds" 5000
 
 
 
 event "fw suppressed Greenrock"
 	system Shaula
 		government "Free Worlds"
-		fleet "Small Free Worlds" 500
-		fleet "Large Free Worlds" 800
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 5000
+		remove fleet "Small Core Pirates"
+		remove fleet "Large Core Pirates"
+		remove fleet "Small Northern Pirates"
+		remove fleet "Large Northern Pirates"
+		remove fleet "Large Militia"
+		add fleet "Small Free Worlds" 500
+		add fleet "Large Free Worlds" 800
+		"set period" fleet "Small Southern Pirates" 3000
+		"set period" fleet "Large Southern Pirates" 5000
 
 
 
 event "fw abandoned Greenrock"
 	system Shaula
 		government Pirate
-		fleet "Small Southern Pirates" 500
-		fleet "Large Southern Pirates" 800
-		fleet "Small Core Pirates" 4000
-		fleet "Large Core Pirates" 7000
-		fleet "Small Northern Pirates" 5000
-		fleet "Large Northern Pirates" 9000
-		fleet "Large Free Worlds" 9000
+		remove fleet "Small Free Worlds"
+		"set period" fleet "Small Southern Pirates" 500
+		"set period" fleet "Large Southern Pirates" 800
+		add fleet "Small Core Pirates" 4000
+		add fleet "Large Core Pirates" 7000
+		add fleet "Small Northern Pirates" 5000
+		add fleet "Large Northern Pirates" 9000
+		"set period" fleet "Large Free Worlds" 9000
 
 
 
@@ -1138,41 +1046,33 @@ event "flamethrower available"
 
 event "navy occupying the south"
 	system Rastaban
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		add fleet "Small Southern Merchants" 1200
-		add fleet "Large Southern Merchants" 2400
-		add fleet "Small Republic" 1125
+		"set period" fleet "Small Southern Merchants" 1200
+		"set period" fleet "Large Southern Merchants" 2400
+		"set period" fleet "Small Republic" 500
 	system Girtab
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 900
-		add fleet "Large Southern Merchants" 2000
+		"set period" fleet "Small Southern Merchants" 900
+		"set period" fleet "Large Southern Merchants" 2000
 		add fleet "Small Republic" 500
 		add fleet "Large Republic" 700
 	system Albaldah
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		add fleet "Small Southern Merchants" 1000
-		add fleet "Large Southern Merchants" 1200
+		"set period" fleet "Small Southern Merchants" 1000
+		"set period" fleet "Large Southern Merchants" 1200
 		add fleet "Small Republic" 500
 		add fleet "Large Republic" 700
 	system "Delta Sagittarii"
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
 		remove fleet "Small Militia"
 		remove fleet "Small Southern Pirates"
-		add fleet "Small Southern Merchants" 1200
-		add fleet "Large Southern Merchants" 4000
+		"set period" fleet "Small Southern Merchants" 1200
+		"set period" fleet "Large Southern Merchants" 4000
 		add fleet "Small Republic" 500
 		add fleet "Large Republic" 700
 
@@ -1297,13 +1197,13 @@ event "fw southern expansion"
 		add fleet "Navy Surveillance" 5000
 	system Rastaban
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 2400
-		fleet "Small Free Worlds" 500
-		fleet "Large Free Worlds" 700
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Navy Surveillance" 2000
+		add fleet "Small Southern Merchants" 1200
+		add fleet "Large Southern Merchants" 2400
+		"set period" fleet "Small Free Worlds" 500
+		add fleet "Large Free Worlds" 700
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 7000
+		add fleet "Navy Surveillance" 2000
 	system Girtab
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
@@ -1333,8 +1233,8 @@ event "fw southern expansion"
 	system "Kaus Borealis"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Navy Surveillance"
-		add fleet "Small Republic" 628
-		add fleet "Large Republic" 1333
+		"set period" fleet "Small Republic" 400
+		"set period" fleet "Large Republic" 500
 	planet "New Iceland"
 		add description `	In the wake of their defeat in the south, the Navy has begun to set up a massive new base here on New Iceland, in order to allow them to continue to have a strong presence in this sector.`
 
@@ -1344,22 +1244,18 @@ event "fw occupying the north"
 	system Alioth
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		remove fleet "Small Republic"
-		remove fleet "Large Republic"
-		remove fleet "Navy Surveillance"
 		add fleet "Small Free Worlds" 500
 		add fleet "Large Free Worlds" 800
-		add fleet "Small Republic" 5000
-		add fleet "Large Republic" 6000
-		add fleet "Navy Surveillance" 4000
+		"set period" fleet "Small Republic" 5000
+		"set period" fleet "Large Republic" 6000
+		"set period" fleet "Navy Surveillance" 4000
 	system Alphecca
 		remove fleet "Small Southern Pirates"
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
-		remove fleet "Navy Surveillance"
 		add fleet "Small Free Worlds" 1200
 		add fleet "Large Free Worlds" 2000
-		add fleet "Navy Surveillance" 6000
+		"set period" fleet "Navy Surveillance" 6000
 	system Boral
 		remove fleet "Small Southern Pirates"
 		remove fleet "Small Republic"
@@ -1369,22 +1265,18 @@ event "fw occupying the north"
 		add fleet "Large Free Worlds" 3800
 	system Seginus
 		remove fleet "Small Southern Pirates"
-		remove fleet "Small Republic"
-		remove fleet "Large Republic"
-		remove fleet "Navy Surveillance"
 		add fleet "Small Free Worlds" 700
 		add fleet "Large Free Worlds" 1100
-		add fleet "Small Republic" 5000
-		add fleet "Large Republic" 6000
-		add fleet "Navy Surveillance" 4000
+		"set period" fleet "Small Republic" 5000
+		"set period" fleet "Large Republic" 6000
+		"set period" fleet "Navy Surveillance" 4000
 	system Wei
 		remove fleet "Small Southern Pirates"
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
-		remove fleet "Navy Surveillance"
 		add fleet "Small Free Worlds" 800
 		add fleet "Large Free Worlds" 1000
-		add fleet "Navy Surveillance" 4000
+		"set period" fleet "Navy Surveillance" 4000
 
 
 
@@ -1427,27 +1319,31 @@ mission "FW Clink Prison Closes"
 event "alphas capture Poisonwood"
 	system Graffias
 		government Pirate
-		fleet "Small Free Worlds" 10000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Human Miners"
+		add fleet "Small Free Worlds" 10000
 
 event "liberation of Poisonwood"
 	system Graffias
 		government Neutral
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Southern Pirates" 6000
-		fleet "Small Free Worlds" 700
-		fleet "Large Free Worlds" 1200
-		fleet "Human Miners" 2000
+		add fleet "Small Southern Merchants" 1000
+		add fleet "Large Southern Merchants" 4000
+		add fleet "Small Southern Pirates" 6000
+		"set period" fleet "Small Free Worlds" 700
+		add fleet "Large Free Worlds" 1200
+		add fleet "Human Miners" 2000
 
 event "Poisonwood reverts to Republic"
 	system Graffias
 		government Republic
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Southern Pirates" 4000
-		fleet "Small Free Worlds" 1500
-		fleet "Large Free Worlds" 2600
-		fleet "Human Miners" 2000
+		add fleet "Small Southern Merchants" 1000
+		add fleet "Large Southern Merchants" 4000
+		add fleet "Small Southern Pirates" 4000
+		"set period" fleet "Small Free Worlds" 1500
+		add fleet "Large Free Worlds" 2600
+		add fleet "Human Miners" 2000
 
 event "death of nguyen"
 
@@ -1484,12 +1380,13 @@ event "bloodsea joins free worlds"
 		description `	Until recently, this was a pirate world, but as the Free Worlds continued to expand they saw the writing on the wall and decided to become a civilized world. The Free Worlds is building a new spaceport here, but that will take months, and in the meantime the old spaceport is still in use.`
 	system Antares
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 700
-		fleet "Large Southern Merchants" 1400
-		fleet "Small Free Worlds" 500
-		fleet "Large Free Worlds" 3000
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 5000
+		remove fleet "Large Milita"
+		add fleet "Small Southern Merchants" 700
+		add fleet "Large Southern Merchants" 1400
+		add fleet "Small Free Worlds" 500
+		"set period" fleet "Large Free Worlds" 3000
+		"set period" fleet "Small Southern Pirates" 2000
+		"set period" fleet "Large Southern Pirates" 5000
 
 
 
@@ -1504,21 +1401,24 @@ event "bloodsea spaceport completed"
 
 event "battle for bloodsea"
 	system Antares
-		fleet "Small Free Worlds" 4000
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		"set period" fleet "Large Free Worlds" 10000
 
 
 
 event "bloodsea independent"
 	system Antares
 		government Independent
-		fleet "Small Independent" 800
-		fleet "Large Independent" 1500
-		fleet "Small Southern Merchants" 2000
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Southern Pirates" 1600
-		fleet "Large Southern Pirates" 3000
-		fleet "Small Free Worlds" 800
-		fleet "Large Free Worlds" 1500
+		add fleet "Small Independent" 800
+		add fleet "Large Independent" 1500
+		add fleet "Small Southern Merchants" 2000
+		add fleet "Large Southern Merchants" 2000
+		add fleet "Small Southern Pirates" 1600
+		add fleet "Large Southern Pirates" 3000
+		add fleet "Small Free Worlds" 800
+		"set period" fleet "Large Free Worlds" 1500
 	planet Bloodsea
 		description `Bloodsea is nearly uninhabited, except for a few small outposts. Its name comes from the planet's oceans, which are blood-red due to rhodophyte algae. Although the climate is temperate and there are many white sand beaches, no one comes here hoping to go swimming.`
 		description `	Until recently, this was a pirate world, but they are now officially "independent," forswearing support for piracy and other criminal activity as a result of being dominated by the Free Worlds militia. You get the feeling that most of the locals are not too fond of the Free Worlds, however.`
@@ -1531,19 +1431,23 @@ event "albatross joins free worlds"
 		description `	Recently, the Free Worlds has liberated Albatross from their pirate oppressors, but many of the locals remain skeptical, seeing the Free Worlds as little different from the other protection rackets that have held sway over them.`
 	system Nunki
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 700
-		fleet "Large Southern Merchants" 1400
-		fleet "Small Free Worlds" 500
-		fleet "Large Free Worlds" 3000
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 5000
+		remove fleet "Small Militia"
+		"set period" fleet "Small Southern Merchants" 700
+		add fleet "Large Southern Merchants" 1400
+		add fleet "Small Free Worlds" 500
+		add fleet "Large Free Worlds" 3000
+		"set period" fleet "Small Southern Pirates" 2000
+		"set period" fleet "Large Southern Pirates" 5000
 
 
 
 event "battle for zeta aquilae"
 	"reputation: Republic" = -1000
 	system "Zeta Aquilae"
-		fleet "Small Southern Merchants" 5000
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		"set period" fleet "Small Southern Merchants" 5000
 
 
 
@@ -1560,70 +1464,56 @@ event "fw expanded and cut"
 		government "Free Worlds"
 	system "Delta Sagittarii"
 		government Republic
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
 		remove fleet "Small Free Worlds"
-		remove fleet "Large Free Worlds"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		remove fleet "Human Miners"
-		add fleet "Small Southern Merchants" 2000
-		add fleet "Large Southern Merchants" 6000
+		"set period" fleet "Small Southern Merchants" 2000
+		"set period" fleet "Large Southern Merchants" 6000
 		add fleet "Small Republic" 500
 		add fleet "Large Republic" 700
-		add fleet "Large Free Worlds" 3000
-		add fleet "Human Miners" 6000
+		"set period" fleet "Large Free Worlds" 3000
+		"set period" fleet "Human Miners" 6000
 	system Rastaban
 		government Republic
-		remove fleet "Large Southern Merchants"
 		remove fleet "Small Free Worlds"
-		remove fleet "Large Free Worlds"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		add fleet "Small Southern Merchants" 6000
-		add fleet "Large Southern Merchants" 4000
+		"set period" fleet "Small Southern Merchants" 1000
+		"set period" fleet "Large Southern Merchants" 4000
 		add fleet "Small Republic" 700
 		add fleet "Large Republic" 900
-		add fleet "Large Free Worlds" 2000
+		"set period" fleet "Large Free Worlds" 2000
 	system Girtab
 		government Republic
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
 		remove fleet "Small Free Worlds"
-		remove fleet "Large Free Worlds"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		add fleet "Small Southern Merchants" 1000
-		add fleet "Large Southern Merchants" 3000
+		"set period" fleet "Small Southern Merchants" 1000
+		"set period" fleet "Large Southern Merchants" 3000
 		add fleet "Small Republic" 900
 		add fleet "Large Republic" 1200
-		add fleet "Large Free Worlds" 1800
+		"set period" fleet "Large Free Worlds" 1800
 	system Lesath
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
 		remove fleet "Small Free Worlds"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		add fleet "Small Southern Merchants" 6000
-		add fleet "Large Southern Merchants" 9000
+		"set period" fleet "Small Southern Merchants" 6000
+		"set period" fleet "Large Southern Merchants" 9000
 		add fleet "Small Republic" 1000
 		add fleet "Large Republic" 1000
-		add fleet "Large Free Worlds" 2933
+		"set period" fleet "Large Free Worlds" 800
 	system "Alpha Arae"
-		remove fleet "Small Southern Merchants"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		remove fleet "Small Republic"
-		remove fleet "Large Republic"
 		remove fleet "Navy Surveillance"
-		add fleet "Small Southern Merchants" 5000
-		add fleet "Large Southern Merchants" 24000
-		add fleet "Small Republic" 800
-		add fleet "Large Republic" 1000
+		"set period" fleet "Small Southern Merchants" 5000
+		"set period" fleet "Large Southern Merchants" 6000
+		"set period" fleet "Small Republic" 800
+		"set period" fleet "Large Republic" 1000
 		add fleet "Large Free Worlds" 3000
 
 
@@ -1691,17 +1581,29 @@ event "deep sky tech available"
 
 
 
+event "fw empty gienah"
+	system Gienah
+		remove fleet "Large Syndicate"
+		remove fleet "Large Core Pirates"
+		"set period" fleet "Small Core Pirates" 5000
+
+event "fw restore gienah"
+	system Gienah
+		"set period" fleet "Small Core Pirates" 500
+		add fleet "Large Core Pirates" 800
+		add fleet "Large Syndicate" 5000
+
+
+
 event "navy out of rastaban"
 	system Rastaban
 		government "Free Worlds"
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
-		add fleet "Small Southern Merchants" 1200
-		add fleet "Large Southern Merchants" 2400
+		"set period" fleet "Small Southern Merchants" 1200
+		"set period" fleet "Large Southern Merchants" 2400
 		add fleet "Small Free Worlds" 500
-		add fleet "Large Free Worlds" 1076
+		"set period" fleet "Large Free Worlds" 700
 		add fleet "Small Southern Pirates" 3000
 		add fleet "Large Southern Pirates" 7000
 		add fleet "Navy Surveillance" 2000
@@ -1709,10 +1611,10 @@ event "navy out of rastaban"
 		government Neutral
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
-		add fleet "Small Southern Merchants" 9000
-		add fleet "Large Southern Merchants" 6000
+		"set period" fleet "Small Southern Merchants" 900
+		"set period" fleet "Large Southern Merchants" 2000
 		add fleet "Small Free Worlds" 1000
-		add fleet "Large Free Worlds" 30600
+		"set period" fleet "Large Free Worlds" 1700
 		add fleet "Small Southern Pirates" 3000
 		add fleet "Large Southern Pirates" 7000
 		add fleet "Navy Surveillance" 5000
@@ -1720,37 +1622,32 @@ event "navy out of rastaban"
 		government "Free Worlds"
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
-		add fleet "Small Southern Merchants" 3000
-		add fleet "Large Southern Merchants" 12000
+		"set period" fleet "Small Southern Merchants" 1200
+		"set period" fleet "Large Southern Merchants" 4000
 		add fleet "Small Free Worlds" 600
-		add fleet "Large Free Worlds" 1285
+		"set period" fleet "Large Free Worlds" 900
 		add fleet "Small Southern Pirates" 3000
 		add fleet "Large Southern Pirates" 7000
 		add fleet "Navy Surveillance" 3000
-		add fleet "Human Miners" 12000
+		"set period" fleet "Human Miners" 4000
 	system Lesath
-		remove fleet "Large Free Worlds"
-		remove fleet "Large Free Worlds"
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
-		add fleet "Small Southern Merchants" 923
-		add fleet "Large Southern Merchants" 1945
-		add fleet "Small Free Worlds" 800
-		add fleet "Large Free Worlds" 1100
+		"set period" fleet "Small Southern Merchants" 800
+		"set period" fleet "Large Southern Merchants" 1600
+		"set period" fleet "Small Free Worlds" 800
+		"set period" fleet "Large Free Worlds" 1100
 		add fleet "Small Southern Pirates" 2000
 		add fleet "Large Southern Pirates" 5000
 		add fleet "Navy Surveillance" 4000
 	system "Alpha Arae"
-		remove fleet "Large Southern Merchants"
 		remove fleet "Large Free Worlds"
-		remove fleet "Small Republic"
-		remove fleet "Large Republic"
-		add fleet "Small Southern Merchants" 3620
-		add fleet "Large Southern Merchants" 8000
+		"set period" fleet "Small Southern Merchants" 2100
+		"set period" fleet "Large Southern Merchants" 8000
 		add fleet "Small Southern Pirates" 6000
 		add fleet "Large Southern Pirates" 13000
-		add fleet "Small Republic" 900
-		add fleet "Large Republic" 800
+		"set period" fleet "Small Republic" 900
+		"set period" fleet "Large Republic" 800
 		add fleet "Navy Surveillance" 1200
 
 
@@ -1767,16 +1664,12 @@ event "stack core for sale"
 
 event "syndicate occupies sol"
 	system Sol
-		remove fleet "Small Northern Merchants"
-		remove fleet "Large Northern Merchants"
-		remove fleet "Small Republic"
-		remove fleet "Large Republic"
-		add fleet "Small Northern Merchants" 500
-		add fleet "Large Northern Merchants" 700
-		add fleet "Small Republic" 800
-		add fleet "Large Republic" 1200
-		add fleet "Small Core Merchants" 9000
-		add fleet "Large Core Merchants" 4666
+		"set period" fleet "Small Northern Merchants" 500
+		"set period" fleet "Large Northern Merchants" 700
+		"set period" fleet "Small Republic" 800
+		"set period" fleet "Large Republic" 1200
+		"set period" fleet "Small Core Merchants" 900
+		"set period" fleet "Large Core Merchants" 1400
 		add fleet "Small Syndicate" 400
 		add fleet "Large Syndicate" 600
 
@@ -1797,7 +1690,7 @@ event "pug invasion"
 	unvisit Peacock
 	system "Zeta Aquilae"
 		government Pug
-		add fleet "Small Southern Merchants" 1250
+		"set period" fleet "Small Southern Merchants" 1000
 		add fleet "Large Southern Merchants" 3000
 		add fleet "Small Pug" 1000
 		add fleet "Large Pug" 2000
@@ -1838,11 +1731,9 @@ event "pug invasion 2"
 	system Vega
 		government Pug
 		remove fleet "Small Republic"
-		remove fleet "Small Republic"
 		remove fleet "Large Republic"
-		remove fleet "Large Republic"
-		add fleet "Small Northern Merchants" 4000
-		add fleet "Large Northern Merchants" 12000
+		"set period" fleet "Small Northern Merchants" 800
+		"set period" fleet "Large Northern Merchants" 3000
 		add fleet "Small Pug" 800
 		add fleet "Large Pug" 1200
 	system Altair
@@ -1914,18 +1805,14 @@ event "pug invasion 4"
 	unvisit Diphda
 	unvisit Ankaa
 	system Sol
-		remove fleet "Small Core Merchants"
-		remove fleet "Small Core Merchants"
-		remove fleet "Large Core Merchants"
-		remove fleet "Large Core Merchants"
 		remove fleet "Small Syndicate"
 		remove fleet "Large Syndicate"
-		add fleet "Small Northern Merchants" 750
-		add fleet "Large Northern Merchants" 1750
-		add fleet "Small Republic" 2400
-		add fleet "Large Republic" 3600
-		add fleet "Small Core Merchants" 1000
-		add fleet "Large Core Merchants" 2000
+		"set period" fleet "Small Northern Merchants" 300
+		"set period" fleet "Large Northern Merchants" 500
+		"set period" fleet "Small Republic" 600
+		"set period" fleet "Large Republic" 900
+		"set period" fleet "Small Core Merchants" 1000
+		"set period" fleet "Large Core Merchants" 2000
 	system Diphda
 		government Pug
 		remove fleet "Small Syndicate"
@@ -1953,9 +1840,11 @@ event "fw syndicate welcoming"
 		bribe .08
 	system Algenib
 		government "Syndicate (Extremist)"
-		fleet "Small Core Pirates" 1500
-		fleet "Large Core Pirates" 2000
-		fleet "Syndicate Extremists" 200
+		remove fleet "Small Core Merchants"
+		remove fleet "Large Syndicate"
+		"set period" fleet "Small Core Pirates" 1500
+		"set period" fleet "Large Core Pirates" 2000
+		add fleet "Syndicate Extremists" 200
 
 
 
@@ -1968,13 +1857,11 @@ event "at war with the pug"
 			"Syndicate" -.01
 			"Syndicate (Extremist)" -.01
 	system "Delta Capricorni"
-		remove fleet "Small Core Merchants"
 		remove fleet "Large Core Merchants"
 		remove fleet "Small Pug"
 		remove fleet "Large Pug"
-		remove fleet "Human Miners"
-		add fleet "Small Core Merchants" 1500
-		add fleet "Human Miners" 6000
+		"set period" fleet "Small Core Merchants" 1500
+		"set period" fleet "Human Miners" 6000
 
 
 
@@ -1990,20 +1877,25 @@ event "reconnected delta capricorni"
 		add fleet "Large Core Merchants" 3000
 		add fleet "Small Pug" 2000
 		add fleet "Large Syndicate" 400
-		add fleet "Human Miners" 6000
+		"set period" fleet "Human Miners" 3000
 
 
 
 event "battle for altair"
 	system Altair
-		fleet "Small Core Merchants" 1500
+		remove fleet "Large Core Merchants"
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		remove fleet "Small Pug"
+		remove fleet "Large Pug"
+		"set period" fleet "Small Core Merchants" 1500
 
 
 
 event "liberation of altair"
 	system Altair
 		government Republic
-		add fleet "Small Core Merchants" 3000
+		"set period" fleet "Small Core Merchants" 1000
 		add fleet "Large Core Merchants" 2000
 		add fleet "Small Pug" 2000
 		add fleet "Large Syndicate" 800
@@ -2016,8 +1908,8 @@ event "reconnected altair"
 		government Republic
 		remove fleet "Small Pug"
 		remove fleet "Large Syndicate"
-		add fleet "Small Core Merchants" 4000
-		add fleet "Large Core Merchants" 3000
+		"set period" fleet "Small Core Merchants" 800
+		"set period" fleet "Large Core Merchants" 1200
 
 
 
@@ -2184,7 +2076,10 @@ event "battle of algenib"
 		"attitude toward"
 			"Syndicate (Extremist)" -.1
 	system Algenib
-		fleet "Small Syndicate" 5000
+		remove fleet "Small Core Pirates"
+		remove fleet "Large Core Pirates"
+		remove fleet "Syndicate Extremists"
+		add fleet "Small Syndicate" 5000
 	"reputation: Syndicate (Extremist)" <?= -1000
 
 
@@ -2192,35 +2087,46 @@ event "battle of algenib"
 event "navy occupies algenib"
 	system Algenib
 		government Republic
-		fleet "Small Republic" 500
-		fleet "Large Republic" 800
-		fleet "Large Syndicate" 800
+		remove fleet "Small Syndicate"
+		add fleet "Small Republic" 500
+		add fleet "Large Republic" 800
+		add fleet "Large Syndicate" 800
 	system Gienah
 		government Republic
-		fleet "Small Republic" 800
-		fleet "Large Republic" 1200
-		fleet "Large Syndicate" 1000
+		remove fleet "Small Core Pirates"
+		remove fleet "Large Core Pirates"
+		add fleet "Small Republic" 800
+		add fleet "Large Republic" 1200
+		"set period" fleet "Large Syndicate" 1000
 
 
 
 event "navy done with algenib"
 	system Algenib
 		government Pirate
-		fleet "Small Core Pirates" 300
-		fleet "Large Core Pirates" 500
-		fleet "Large Syndicate" 800
-		fleet "Small Core Merchants" 600
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Core Pirates" 300
+		add fleet "Large Core Pirates" 500
+		add fleet "Small Core Merchants" 600
 	system Gienah
 		government Pirate
-		fleet "Small Core Pirates" 500
-		fleet "Large Core Pirates" 800
-		fleet "Large Syndicate" 5000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Core Pirates" 500
+		add fleet "Large Core Pirates" 800
+		"set period" fleet "Large Syndicate" 5000
 
 
 
 event "fwc southern battle"
 	system "Delta Sagittarii"
-		fleet "Large Free Worlds" 4000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Human Miners"
+		"set period" fleet "Large Free Worlds" 4000
 	system Rastaban
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
@@ -2238,15 +2144,14 @@ event "fwc southern liberation"
 		add fleet "Small Southern Merchants" 1200
 		add fleet "Large Southern Merchants" 4000
 		add fleet "Small Free Worlds" 600
-		add fleet "Large Free Worlds" 1161
+		"set period" fleet "Large Free Worlds" 900
 		add fleet "Small Southern Pirates" 3000
 		add fleet "Large Southern Pirates" 7000
 		add fleet "Large Republic" 3000
 		add fleet "Human Miners" 4000
 	system Rastaban
 		government "Free Worlds"
-		remove fleet "Small Southern Merchants"
-		add fleet "Small Southern Merchants" 1200
+		"set period" fleet "Small Southern Merchants" 1200
 		add fleet "Large Southern Merchants" 6000
 		add fleet "Small Free Worlds" 500
 		add fleet "Large Free Worlds" 700
@@ -2255,19 +2160,17 @@ event "fwc southern liberation"
 		add fleet "Large Republic" 3000
 	system Girtab
 		government Neutral
-		add fleet "Small Southern Merchants" 9000
-		add fleet "Large Southern Merchants" 6000
+		"set period" fleet "Small Southern Merchants" 900
+		"set period" fleet "Large Southern Merchants" 2000
 		add fleet "Small Free Worlds" 1000
 		add fleet "Large Free Worlds" 1700
 		add fleet "Small Southern Pirates" 3000
 		add fleet "Large Southern Pirates" 7000
 	system Lesath
-		remove fleet "Large Free Worlds"
-		remove fleet "Large Free Worlds"
-		add fleet "Small Southern Merchants" 923
-		add fleet "Large Southern Merchants" 1945
+		"set period" fleet "Small Southern Merchants" 800
+		"set period" fleet "Large Southern Merchants" 1600
 		add fleet "Small Free Worlds" 800
-		add fleet "Large Free Worlds" 1100
+		"set period" fleet "Large Free Worlds" 1100
 		add fleet "Small Southern Pirates" 2000
 		add fleet "Large Southern Pirates" 5000
 		add fleet "Navy Surveillance" 4000
@@ -2282,8 +2185,6 @@ event "fwc attack kaus borealis"
 	system "Kaus Borealis"
 		remove fleet "Small Southern Merchants"
 		remove fleet "Small Republic"
-		remove fleet "Small Republic"
-		remove fleet "Large Republic"
 		remove fleet "Large Republic"
 		add fleet "Large Free Worlds" 3000
 
@@ -2297,7 +2198,7 @@ event "fwc capture kaus borealis"
 		government "Free Worlds"
 		add fleet "Small Southern Merchants" 2000
 		add fleet "Small Free Worlds" 400
-		add fleet "Large Free Worlds" 461
+		"set period" fleet "Large Free Worlds" 400
 		add fleet "Large Republic" 2000
 	planet "New Iceland"
 		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds. Many of the inhabitants wear dust masks to avoid letting the particulate matter from the volcanoes accumulate in their lungs.`
@@ -2306,27 +2207,28 @@ event "fwc capture kaus borealis"
 
 event "fwc attack cebalrai"
 	system Cebalrai
-		fleet "Small Southern Merchants" 5000
-		fleet "Large Southern Merchants" 6000
+		remove fleet "Small Southern Pirates"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		"set period" fleet "Small Southern Merchants" 5000
+		"set period" fleet "Large Southern Merchants" 6000
 
 
 
 event "fwc capture cebalrai"
 	system Cebalrai
 		government "Free Worlds"
-		add fleet "Small Southern Merchants" 1250
-		add fleet "Large Southern Merchants" 2000
+		"set period" fleet "Small Southern Merchants" 1000
+		"set period" fleet "Large Southern Merchants" 1500
 		add fleet "Small Free Worlds" 400
 		add fleet "Large Free Worlds" 400
 		add fleet "Large Republic" 2000
 	system "Kaus Borealis"
 		government "Free Worlds"
-		remove fleet "Small Free Worlds"
-		remove fleet "Large Free Worlds"
-		remove fleet "Large Free Worlds"
 		remove fleet "Large Republic"
-		add fleet "Small Free Worlds" 600
-		add fleet "Large Free Worlds" 700
+		"set period" fleet "Small Free Worlds" 600
+		"set period" fleet "Large Free Worlds" 700
 
 
 
@@ -2338,7 +2240,11 @@ event "fwc solace has nukes"
 
 event "fwc defend cebalrai"
 	system Cebalrai
-		fleet "Large Free Worlds" 6000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Free Worlds"
+		remove fleet "Large Republic"
+		"set period" fleet "Large Free Worlds" 6000
 
 
 
@@ -2347,22 +2253,18 @@ event "fwc defended cebalrai"
 		add fleet "Small Southern Merchants" 1000
 		add fleet "Large Southern Merchants" 1500
 		add fleet "Small Free Worlds" 500
-		add fleet "Large Free Worlds" 666
+		"set period" fleet "Large Free Worlds" 600
 		add fleet "Large Republic" 5000
 	system Sargas
 		remove fleet "Navy Surveillance"
 	system Lesath
-		remove fleet "Small Southern Merchants"
-		remove fleet "Small Southern Merchants"
-		remove fleet "Large Southern Merchants"
-		remove fleet "Large Southern Merchants"
 		remove fleet "Small Free Worlds"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		add fleet "Small Southern Merchants" 6000
-		add fleet "Large Southern Merchants" 9000
-		add fleet "Large Free Worlds" 2933
+		"set period" fleet "Small Southern Merchants" 6000
+		"set period" fleet "Large Southern Merchants" 9000
+		"set period" fleet "Large Free Worlds" 800
 	system Dschubba
 		remove fleet "Navy Surveillance"
 	system Seginus
@@ -2395,14 +2297,19 @@ event "fwc defended cebalrai"
 
 event "fwc attack menkent"
 	system Menkent
-		fleet "Small Southern Merchants" 5000
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		remove fleet "Human Miners"
+		"set period" fleet "Small Southern Merchants" 5000
 
 
 
 event "fwc capture menkent"
 	system Menkent
 		government "Free Worlds"
-		add fleet "Small Southern Merchants" 813
+		"set period" fleet "Small Southern Merchants" 700
 		add fleet "Large Southern Merchants" 1900
 		add fleet "Small Free Worlds" 300
 		add fleet "Large Free Worlds" 400
@@ -2415,7 +2322,12 @@ event "fwc capture menkent"
 
 event "fwc attack vega"
 	system Vega
-		fleet "Small Southern Merchants" 50000
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Human Miners"
+		add fleet "Small Southern Merchants" 50000
 
 
 
@@ -2442,7 +2354,7 @@ event "fwc pug invasion"
 			"Free Worlds" -.01
 	system "Zeta Aquilae"
 		government Pug
-		add fleet "Small Southern Merchants" 1250
+		"set period" fleet "Small Southern Merchants" 1000
 		add fleet "Large Southern Merchants" 3000
 		add fleet "Small Pug" 1000
 		add fleet "Large Pug" 2000
@@ -2525,18 +2437,15 @@ event "fwc navy retakes cebalrai"
 	system Cebalrai
 		government Republic
 		remove fleet "Small Free Worlds"
-		remove fleet "Large Free Worlds"
-		remove fleet "Large Free Worlds"
 		add fleet "Small Republic" 500
-		add fleet "Large Republic" 681
-		add fleet "Large Free Worlds" 5000
+		"set period" fleet "Large Republic" 600
+		"set period" fleet "Large Free Worlds" 5000
 	system Menkent
 		government Republic
 		remove fleet "Small Free Worlds"
-		remove fleet "Large Free Worlds"
 		add fleet "Small Republic" 300
-		add fleet "Large Republic" 500
-		add fleet "Large Free Worlds" 2000
+		"set period" fleet "Large Republic" 400
+		"set period" fleet "Large Free Worlds" 2000
 
 
 
@@ -2590,7 +2499,10 @@ event "fwc peace with the navy"
 event "fwc battle for rasalhague"
 	link Rasalhague Cebalrai
 	system Rasalhague
-		fleet "Small Southern Merchants" 10000
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Pug"
+		remove fleet "Large Pug"
+		"set period" fleet "Small Southern Merchants" 10000
 	government Pug
 		"attitude toward"
 			"Free Worlds" -.01
@@ -2602,7 +2514,7 @@ event "fwc battle for rasalhague"
 event "fwc liberation of rasalhague"
 	system Rasalhague
 		government "Free Worlds"
-		add fleet "Small Southern Merchants" 1764
+		"set period" fleet "Small Southern Merchants" 1500
 		add fleet "Large Southern Merchants" 2000
 		add fleet "Small Republic" 400
 		add fleet "Large Republic" 600
@@ -2631,8 +2543,8 @@ event "fwc liberation of rasalhague"
 		remove fleet "Large Pug"
 	system Deneb
 		add fleet "Small Core Merchants" 10000
-		add fleet "Small Pug" 133
-		add fleet "Large Pug" 111
+		"set period" fleet "Small Pug" 100
+		"set period" fleet "Large Pug" 100
 
 
 
@@ -2645,9 +2557,7 @@ event "fwc reconnect zeta aquilae"
 	link "Zeta Aquilae" Ascella
 	system "Zeta Aquilae"
 		government "Free Worlds"
-		remove fleet "Small Southern Merchants"
-		remove fleet "Small Southern Merchants"
-		add fleet "Small Southern Merchants" 1500
+		"set period" fleet "Small Southern Merchants" 1500
 		add fleet "Large Southern Merchants" 6000
 		add fleet "Small Republic" 400
 		add fleet "Large Republic" 600

--- a/data/events.txt
+++ b/data/events.txt
@@ -1540,6 +1540,13 @@ event "albatross joins free worlds"
 
 
 
+event "battle for zeta aquilae"
+	"reputation: Republic" = -1000
+	system "Zeta Aquilae"
+		fleet "Small Southern Merchants" 5000
+
+
+
 event "fw expanded and cut"
 	system Rasalhague
 		government "Free Worlds"
@@ -1553,38 +1560,71 @@ event "fw expanded and cut"
 		government "Free Worlds"
 	system "Delta Sagittarii"
 		government Republic
-		fleet "Small Southern Merchants" 2000
-		fleet "Large Southern Merchants" 6000
-		fleet "Small Republic" 500
-		fleet "Large Republic" 700
-		fleet "Large Free Worlds" 3000
-		fleet "Human Miners" 6000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Free Worlds"
+		remove fleet "Large Free Worlds"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Navy Surveillance"
+		remove fleet "Human Miners"
+		add fleet "Small Southern Merchants" 2000
+		add fleet "Large Southern Merchants" 6000
+		add fleet "Small Republic" 500
+		add fleet "Large Republic" 700
+		add fleet "Large Free Worlds" 3000
+		add fleet "Human Miners" 6000
 	system Rastaban
 		government Republic
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Republic" 700
-		fleet "Large Republic" 900
-		fleet "Large Free Worlds" 2000
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Free Worlds"
+		remove fleet "Large Free Worlds"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Southern Merchants" 6000
+		add fleet "Large Southern Merchants" 4000
+		add fleet "Small Republic" 700
+		add fleet "Large Republic" 900
+		add fleet "Large Free Worlds" 2000
 	system Girtab
 		government Republic
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 3000
-		fleet "Small Republic" 900
-		fleet "Large Republic" 1200
-		fleet "Large Free Worlds" 1800
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Free Worlds"
+		remove fleet "Large Free Worlds"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Southern Merchants" 1000
+		add fleet "Large Southern Merchants" 3000
+		add fleet "Small Republic" 900
+		add fleet "Large Republic" 1200
+		add fleet "Large Free Worlds" 1800
 	system Lesath
-		fleet "Small Southern Merchants" 6000
-		fleet "Large Southern Merchants" 9000
-		fleet "Small Republic" 1000
-		fleet "Large Republic" 1000
-		fleet "Large Free Worlds" 800
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Free Worlds"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Southern Merchants" 6000
+		add fleet "Large Southern Merchants" 9000
+		add fleet "Small Republic" 1000
+		add fleet "Large Republic" 1000
+		add fleet "Large Free Worlds" 2933
 	system "Alpha Arae"
-		fleet "Small Southern Merchants" 5000
-		fleet "Large Southern Merchants" 6000
-		fleet "Small Republic" 800
-		fleet "Large Republic" 1000
-		fleet "Large Free Worlds" 3000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Southern Merchants" 5000
+		add fleet "Large Southern Merchants" 24000
+		add fleet "Small Republic" 800
+		add fleet "Large Republic" 1000
+		add fleet "Large Free Worlds" 3000
 
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -1436,7 +1436,7 @@ event "liberation of Poisonwood"
 		fleet "Large Southern Merchants" 4000
 		fleet "Small Southern Pirates" 6000
 		fleet "Small Free Worlds" 700
-		fleet "Small Free Worlds" 1200
+		fleet "Large Free Worlds" 1200
 		fleet "Human Miners" 2000
 
 event "Poisonwood reverts to Republic"
@@ -1446,7 +1446,7 @@ event "Poisonwood reverts to Republic"
 		fleet "Large Southern Merchants" 4000
 		fleet "Small Southern Pirates" 4000
 		fleet "Small Free Worlds" 1500
-		fleet "Small Free Worlds" 2600
+		fleet "Large Free Worlds" 2600
 		fleet "Human Miners" 2000
 
 event "death of nguyen"

--- a/data/events.txt
+++ b/data/events.txt
@@ -2276,27 +2276,29 @@ event "fwc southern liberation"
 
 event "fwc attack kaus borealis"
 	system "Alpha Arae"
-		fleet "Small Southern Merchants" 5000
-		fleet "Large Southern Merchants" 6000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Large Free Worlds"
 	system "Kaus Borealis"
-		fleet "Large Southern Merchants" 4000
-		fleet "Large Free Worlds" 3000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Small Republic"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Large Republic"
+		add fleet "Large Free Worlds" 3000
 
 
 
 event "fwc capture kaus borealis"
 	system "Alpha Arae"
-		fleet "Small Southern Merchants" 5000
-		fleet "Large Southern Merchants" 6000
-		fleet "Small Free Worlds" 1000
-		fleet "Large Free Worlds" 1000
+		add fleet "Small Free Worlds" 1000
+		add fleet "Large Free Worlds" 1000
 	system "Kaus Borealis"
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 2000
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Free Worlds" 400
-		fleet "Large Free Worlds" 400
-		fleet "Large Republic" 2000
+		add fleet "Small Southern Merchants" 2000
+		add fleet "Small Free Worlds" 400
+		add fleet "Large Free Worlds" 461
+		add fleet "Large Republic" 2000
 	planet "New Iceland"
 		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds. Many of the inhabitants wear dust masks to avoid letting the particulate matter from the volcanoes accumulate in their lungs.`
 
@@ -2312,17 +2314,19 @@ event "fwc attack cebalrai"
 event "fwc capture cebalrai"
 	system Cebalrai
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 1500
-		fleet "Small Free Worlds" 400
-		fleet "Large Free Worlds" 400
-		fleet "Large Republic" 2000
+		add fleet "Small Southern Merchants" 1250
+		add fleet "Large Southern Merchants" 2000
+		add fleet "Small Free Worlds" 400
+		add fleet "Large Free Worlds" 400
+		add fleet "Large Republic" 2000
 	system "Kaus Borealis"
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 2000
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Free Worlds" 600
-		fleet "Large Free Worlds" 700
+		remove fleet "Small Free Worlds"
+		remove fleet "Large Free Worlds"
+		remove fleet "Large Free Worlds"
+		remove fleet "Large Republic"
+		add fleet "Small Free Worlds" 600
+		add fleet "Large Free Worlds" 700
 
 
 
@@ -2340,73 +2344,52 @@ event "fwc defend cebalrai"
 
 event "fwc defended cebalrai"
 	system Cebalrai
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 1500
-		fleet "Small Free Worlds" 500
-		fleet "Large Free Worlds" 600
-		fleet "Large Republic" 5000
+		add fleet "Small Southern Merchants" 1000
+		add fleet "Large Southern Merchants" 1500
+		add fleet "Small Free Worlds" 500
+		add fleet "Large Free Worlds" 666
+		add fleet "Large Republic" 5000
 	system Sargas
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2500
-		fleet "Small Free Worlds" 1000
-		fleet "Large Free Worlds" 1500
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
+		remove fleet "Navy Surveillance"
 	system Lesath
-		fleet "Small Southern Merchants" 6000
-		fleet "Large Southern Merchants" 9000
-		fleet "Large Free Worlds" 800
+		remove fleet "Small Southern Merchants"
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Free Worlds"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Southern Merchants" 6000
+		add fleet "Large Southern Merchants" 9000
+		add fleet "Large Free Worlds" 2933
 	system Dschubba
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 2600
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 6000
-		fleet "Small Free Worlds" 2000
-		fleet "Large Free Worlds" 3000
-		fleet "Human Miners" 1750
+		remove fleet "Navy Surveillance"
 	system Seginus
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 2700
-		fleet "Small Free Worlds" 700
-		fleet "Large Free Worlds" 1100
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
 	system Alnasl
-		fleet "Small Southern Merchants" 1300
-		fleet "Large Southern Merchants" 2500
-		fleet "Small Southern Pirates" 6000
-		fleet "Small Free Worlds" 2000
-		fleet "Large Free Worlds" 3000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Free Worlds" 2000
+		add fleet "Large Free Worlds" 3000
 	system Eber
-		fleet "Small Southern Merchants" 1900
-		fleet "Large Southern Merchants" 2900
-		fleet "Small Southern Pirates" 3000
-		fleet "Small Free Worlds" 2000
-		fleet "Large Free Worlds" 3000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Free Worlds" 2000
+		add fleet "Large Free Worlds" 3000
 	system "Delta Sagittarii"
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Free Worlds" 600
-		fleet "Large Free Worlds" 900
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Human Miners" 4000
+		remove fleet "Large Republic"
 	system Rastaban
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 2400
-		fleet "Small Free Worlds" 500
-		fleet "Large Free Worlds" 700
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
+		remove fleet "Large Republic"
 	system Albaldah
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 1200
-		fleet "Small Free Worlds" 900
-		fleet "Large Free Worlds" 1900
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Human Miners" 3000
+		remove fleet "Navy Surveillance"
 
 
 
@@ -2419,12 +2402,12 @@ event "fwc attack menkent"
 event "fwc capture menkent"
 	system Menkent
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 700
-		fleet "Large Southern Merchants" 1900
-		fleet "Small Free Worlds" 300
-		fleet "Large Free Worlds" 400
-		fleet "Large Republic" 2000
-		fleet "Human Miners" 2000
+		add fleet "Small Southern Merchants" 813
+		add fleet "Large Southern Merchants" 1900
+		add fleet "Small Free Worlds" 300
+		add fleet "Large Free Worlds" 400
+		add fleet "Large Republic" 2000
+		add fleet "Human Miners" 2000
 	planet "New Austria"
 		description `New Austria is a rugged mountain world, full of snow-capped peaks and valleys so deep and so steep that they rarely see sunlight. The few settlements that have been built here were developed for mining sapphires and rubies; the sapphires found in New Austria range from blue to yellow to black to clear in color, and are used both for industrial abrasives and for jewelry. For centuries the locals have been trying to find a deposit of diamonds, which would sell for much higher prices than sapphires, and local folklore revolves around the prosperity that would come to this world if diamonds were ever discovered.`
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -745,113 +745,138 @@ event "initial deployment 4"
 	planet Geminus
 		"required reputation" 10
 	system Sargas
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2500
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 5000
-		fleet "Small Free Worlds" 1000
-		fleet "Large Free Worlds" 1500
-		fleet "Navy Surveillance" 800
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 4200
+		add fleet "Large Southern Merchants" 15000
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 5000
+		add fleet "Small Free Worlds" 1000
+		add fleet "Large Free Worlds" 1500
+		add fleet "Navy Surveillance" 800
 	system Dschubba
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 2600
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 6000
-		fleet "Small Free Worlds" 2000
-		fleet "Large Free Worlds" 3000
-		fleet "Navy Surveillance" 800
-		fleet "Human Miners" 2000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 4000
+		add fleet "Large Southern Merchants" 19500
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 6000
+		add fleet "Small Free Worlds" 2000
+		add fleet "Large Free Worlds" 3000
+		add fleet "Navy Surveillance" 800
 	system Lesath
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 1600
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Small Free Worlds" 800
-		fleet "Large Free Worlds" 1100
-		fleet "Navy Surveillance" 800
+		remove fleet "Small Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 4000
+		add fleet "Large Southern Merchants" 8000
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 7000
+		add fleet "Small Free Worlds" 800
+		add fleet "Large Free Worlds" 1100
+		add fleet "Navy Surveillance" 800
 	system Atria
-		fleet "Small Southern Merchants" 700
-		fleet "Large Southern Merchants" 2600
-		fleet "Small Southern Pirates" 5000
-		fleet "Large Southern Pirates" 8000
-		fleet "Small Free Worlds" 1000
-		fleet "Large Free Worlds" 2100
-		fleet "Human Miners" 2000
+		remove fleet "Small Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 2333
+		add fleet "Large Southern Merchants" 19500
+		add fleet "Small Southern Pirates" 5000
+		add fleet "Large Southern Pirates" 8000
+		add fleet "Small Free Worlds" 1000
+		add fleet "Large Free Worlds" 2100
 	system Alniyat
-		fleet "Small Southern Merchants" 500
-		fleet "Large Southern Merchants" 600
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 4000
-		fleet "Small Free Worlds" 1500
-		fleet "Large Free Worlds" 4000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		add fleet "Large Southern Merchants" 4200
+		add fleet "Small Free Worlds" 1500
+		add fleet "Large Free Worlds" 4000
 	system Han
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 9000
-		fleet "Small Free Worlds" 3000
-		fleet "Large Free Worlds" 8000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 4000
+		add fleet "Large Southern Merchants" 20000
+		add fleet "Small Southern Pirates" 2000
+		add fleet "Large Southern Pirates" 9000
+		add fleet "Small Free Worlds" 3000
+		add fleet "Large Free Worlds" 8000
 	system Pherkad
-		fleet "Small Southern Merchants" 500
-		fleet "Large Southern Merchants" 700
-		fleet "Small Free Worlds" 900
-		fleet "Large Free Worlds" 1700
-		fleet "Small Southern Pirates" 1000
-		fleet "Large Southern Pirates" 1900
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		add fleet "Large Southern Merchants" 2333
+		add fleet "Small Free Worlds" 900
+		add fleet "Large Free Worlds" 1700
+		add fleet "Small Southern Pirates" 2000
+		add fleet "Large Southern Pirates" 5181
 	system "Beta Lupi"
-		fleet "Small Southern Merchants" 800
-		fleet "Small Southern Pirates" 1100
-		fleet "Large Southern Pirates" 1600
-		fleet "Small Free Worlds" 4000
-		fleet "Large Free Worlds" 8000
-		fleet "Human Miners" 3000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		add fleet "Small Southern Merchants" 4000
+		add fleet "Small Southern Pirates" 4125
+		add fleet "Large Southern Pirates" 4444
+		add fleet "Small Free Worlds" 4000
+		add fleet "Large Free Worlds" 8000
 	system "Yed Prior"
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 1100
-		fleet "Small Southern Pirates" 1000
-		fleet "Large Southern Pirates" 2000
-		fleet "Small Free Worlds" 5000
-		fleet "Large Free Worlds" 8000
-		fleet "Human Miners" 1600
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		add fleet "Large Southern Merchants" 3520
+		add fleet "Small Southern Pirates" 2000
+		add fleet "Large Southern Pirates" 6000
+		add fleet "Small Free Worlds" 5000
+		add fleet "Large Free Worlds" 8000
 	system "Kappa Centauri"
-		fleet "Small Southern Merchants" 900
-		fleet "Large Southern Merchants" 2700
-		fleet "Small Southern Pirates" 1600
-		fleet "Large Southern Pirates" 2000
-		fleet "Small Free Worlds" 3000
-		fleet "Large Free Worlds" 5000
+		remove fleet "Small Militia"
+		add fleet "Small Southern Merchants" 9000
+		add fleet "Large Southern Merchants" 27000
+		add fleet "Small Southern Pirates" 8000
+		add fleet "Large Southern Pirates" 2000
+		add fleet "Small Free Worlds" 3000
+		add fleet "Large Free Worlds" 5000
 	
 	system Rastaban
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 1900
-		fleet "Small Southern Pirates" 4000
-		fleet "Large Southern Pirates" 8000
-		fleet "Small Republic" 900
-		fleet "Large Republic" 700
-		fleet "Navy Surveillance" 1200
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 1000
+		add fleet "Large Southern Merchants" 1900
+		add fleet "Small Southern Pirates" 4000
+		add fleet "Large Southern Pirates" 8000
+		add fleet "Small Republic" 900
+		add fleet "Large Republic" 700
+		add fleet "Navy Surveillance" 1200
 	system Sabik
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 800
-		fleet "Small Free Worlds" 800
-		fleet "Large Free Worlds" 1200
-		fleet "Navy Surveillance" 800
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		add fleet "Small Southern Merchants" 600
+		add fleet "Large Southern Merchants" 800
+		add leet "Small Free Worlds" 4000
+		add fleet "Large Free Worlds" 4800
+		add fleet "Navy Surveillance" 800
 	system Aldhibain
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 800
-		fleet "Small Free Worlds" 600
-		fleet "Large Free Worlds" 600
-		fleet "Small Southern Pirates" 1400
-		fleet "Large Southern Pirates" 3000
-		fleet "Navy Surveillance" 800
-		fleet "Human Miners" 3000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		add fleet "Small Southern Merchants" 600
+		add fleet "Large Southern Merchants" 800
+		add fleet "Large Free Worlds" 4200
+		add fleet "Navy Surveillance" 800
 	system Kornephoros
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 1000
-		fleet "Small Southern Pirates" 5000
-		fleet "Small Free Worlds" 900
-		fleet "Large Free Worlds" 1700
-		fleet "Navy Surveillance" 800
-		fleet "Human Miners" 3000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		add fleet "Small Southern Merchants" 800
+		add fleet "Large Southern Merchants" 1000
+		add fleet "Small Free Worlds" 9000
+		add fleet "Large Free Worlds" 11333
+		add fleet "Navy Surveillance" 800
 
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -970,78 +970,55 @@ event "recapture of Kornephoros"
 
 event "oathkeepers founded"
 	system Canopus
-		fleet "Small Northern Merchants" 900
-		fleet "Large Northern Merchants" 700
-		fleet "Small Oathkeeper" 1000
-		fleet "Large Oathkeeper" 2000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Oathkeeper" 1000
+		add fleet "Large Oathkeeper" 2000
 	system Alheka
-		fleet "Small Northern Merchants" 1000
-		fleet "Large Northern Merchants" 3000
-		fleet "Small Oathkeeper" 1200
-		fleet "Large Oathkeeper" 4000
-		fleet "Small Northern Pirates" 2000
-		fleet "Large Northern Pirates" 2000
-		fleet "Human Miners" 3000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Oathkeeper" 1200
+		add fleet "Large Oathkeeper" 4000
 	system Mirzam
-		fleet "Small Northern Merchants" 2000
-		fleet "Large Northern Merchants" 2000
-		fleet "Small Oathkeeper" 3000
-		fleet "Large Oathkeeper" 4000
-		fleet "Small Northern Pirates" 5000
-		fleet "Large Northern Pirates" 8000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Oathkeeper" 3000
+		add fleet "Large Oathkeeper" 4000
 	system Mebsuta
-		fleet "Small Northern Merchants" 3000
-		fleet "Large Northern Merchants" 5000
-		fleet "Small Northern Pirates" 4000
-		fleet "Large Northern Pirates" 8000
-		fleet "Small Oathkeeper" 12000
+		remove fleet "Small Republic"
+		add fleet "Small Oathkeeper" 12000
 	system Betelgeuse
-		fleet "Small Northern Merchants" 2000
-		fleet "Large Northern Merchants" 800
-		fleet "Small Oathkeeper" 1000
-		fleet "Large Oathkeeper" 2000
-		fleet "Large Northern Pirates" 4000
-		fleet "Human Miners" 3000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Oathkeeper" 1000
+		add fleet "Large Oathkeeper" 2000
 	system Rigel
-		fleet "Small Northern Merchants" 2000
-		fleet "Large Northern Merchants" 4000
-		fleet "Small Oathkeeper" 1000
-		fleet "Large Oathkeeper" 2000
-		fleet "Small Northern Pirates" 3000
-		fleet "Large Northern Pirates" 5000
-		fleet "Human Miners" 2000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Oathkeeper" 1000
+		add fleet "Large Oathkeeper" 2000
 	system Alnitak
-		fleet "Small Northern Pirates" 3000
-		fleet "Large Northern Pirates" 5000
-		fleet "Small Oathkeeper" 500
-		fleet "Large Oathkeeper" 1000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Oathkeeper" 500
+		add fleet "Large Oathkeeper" 1000
 	system Saiph
-		fleet "Small Northern Merchants" 1200
-		fleet "Large Northern Merchants" 2000
-		fleet "Small Northern Pirates" 2000
-		fleet "Large Northern Pirates" 3000
-		fleet "Small Oathkeeper" 1000
-		fleet "Large Oathkeeper" 2000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Oathkeeper" 1000
+		add fleet "Large Oathkeeper" 2000
 	system Mintaka
-		fleet "Small Northern Pirates" 2000
-		fleet "Large Northern Pirates" 2000
-		fleet "Large Oathkeeper" 2000
-		fleet "Small Northern Merchants" 4000
-		fleet "Human Miners" 2000
+		remove fleet "Large Republic"
+		add fleet "Large Oathkeeper" 2000
 	system Almaaz
-		fleet "Small Northern Pirates" 500
-		fleet "Large Northern Pirates" 600
-		fleet "Large Oathkeeper" 4000
+		remove fleet "Large Republic"
+		add fleet "Large Oathkeeper" 4000
 	system Gorvi
-		fleet "Small Northern Pirates" 1000
-		fleet "Large Northern Pirates" 1000
-		fleet "Large Oathkeeper" 4000
-		fleet "Small Northern Merchants" 8000
+		remove fleet "Large Republic"
+		add fleet "Large Oathkeeper" 4000
 	system Tortor
-		fleet "Small Northern Pirates" 1000
-		fleet "Large Northern Pirates" 1000
-		fleet "Large Oathkeeper" 6000
-		fleet "Small Northern Merchants" 6000
+		remove fleet "Large Republic"
+		add fleet "Large Oathkeeper" 6000
 	planet Farpoint
 		add description `	Lately the Navy base on Farpoint is growing, because it has become the new home of the Navy Oathkeepers, a small branch of the Navy that has sworn to stay uninvolved in the conflict with the Free Worlds.`
 
@@ -1070,13 +1047,14 @@ event "plasma turret available"
 
 event "fw conservatory founded"
 	system "Yed Prior"
-		fleet "Small Southern Merchants" 500
-		fleet "Large Southern Merchants" 800
-		fleet "Small Southern Pirates" 1200
-		fleet "Large Southern Pirates" 2400
-		fleet "Small Free Worlds" 1000
-		fleet "Large Free Worlds" 1500
-		fleet "Human Miners" 1600
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 1333
+		add fleet "Large Southern Merchants" 2933
+		add fleet "Small Southern Pirates" 1200
+		add fleet "Large Southern Pirates" 2400
+		add fleet "Small Free Worlds" 1250
+		add fleet "Large Free Worlds" 1846
 	planet Winter
 		add attributes research
 		add description `	Winter is home to the Free Worlds Conservatory, a new university that is focused on making terraforming technology and expertise available at a reasonable price, as well as on ecological protection and renewal.`

--- a/data/events.txt
+++ b/data/events.txt
@@ -129,8 +129,7 @@ event "war begins"
 		"required reputation" 100
 		security .9
 	planet "Bourne"
-		description `Bourne is a well-developed industrial world that was first settled four centuries ago. Its cities are home to some of the richest individuals in this section of the galaxy, but also home to tens of thousands of homeless people, and many others whose factory jobs are barely providing enough to make ends meet.`
-		description `Bourne is also the seat of government for the newly formed Coalition of Free Worlds.`
+		add description `Bourne is also the seat of government for the newly formed Coalition of Free Worlds.`
 
 mission "event: war begins"
 	landing
@@ -183,8 +182,7 @@ event "initial deployment 1"
 		fleet "Large Republic" 400
 		fleet "Navy Surveillance" 2000
 	planet "Ingot"
-		description `Ingot is a volcanic moon, totally unsuitable for life but rich in metal. The miners who work here must spend all their time inside pressurized buildings. Because Ingot has almost no atmosphere to slow them down, meteorites are a constant danger to the colonists. The shells of the buildings have multiple layers, designed to be self-sealing in any but the largest of impacts. Most of the mining is done remotely by robotic vehicles, but someone still needs to be present to control them and to make repairs when something goes wrong.`
-		description `Ingot is also now home to a burgeoning Navy base, although since the planet is so unlivable most of the troops are just living in ships in orbit.`
+		add description `Ingot is also now home to a burgeoning Navy base, although since the planet is so unlivable most of the troops are just living in ships in orbit.`
 	system "Fala"
 		fleet "Small Northern Merchants" 1900
 		fleet "Large Northern Merchants" 3500
@@ -208,8 +206,7 @@ event "initial deployment 1"
 		fleet "Large Southern Pirates" 8000
 		fleet "Navy Surveillance" 2000
 	planet "New Wales"
-		description `New Wales is home to a few mining outposts which extract and refine rare earth minerals and heavy metals. It is dangerous work: the mines are deep underground and prone to noxious gases and cave-ins, and the refineries work with molten radioactive materials and caustic chemicals. Due to the somewhat dim light of the star Algorel, and the cloudiness of the atmosphere, this is not a good world for farming, and the population remains quite small.`
-		description `The Republic Navy has planted a base on New Wales: so far, just a densely packed cluster of prefabricated barracks and infirmary buildings on the outskirts of one of the mining colonies.`
+		add description `The Republic Navy has planted a base on New Wales: so far, just a densely packed cluster of prefabricated barracks and infirmary buildings on the outskirts of one of the mining colonies.`
 	system "Porrima"
 		fleet "Small Southern Merchants" 1400
 		fleet "Large Southern Merchants" 4000
@@ -246,8 +243,7 @@ event "initial deployment 1"
 		fleet "Navy Surveillance" 2000
 		fleet "Human Miners" 2000
 	planet "New Austria"
-		description `New Austria is a rugged mountain world, full of snow-capped peaks and valleys so deep and so steep that they rarely see sunlight. The few settlements that have been built here were developed for mining sapphires and rubies; the sapphires found in New Austria range from blue to yellow to black to clear in color, and are used both for industrial abrasives and for jewelry.`
-		description `The Navy has recently requisitioned one of the abandoned mining towns and begun refurbishing it for a secure military base, with the mining tunnels used as deep underground bunkers.`
+		add description `The Navy has recently requisitioned one of the abandoned mining towns and begun refurbishing it for a secure military base, with the mining tunnels used as deep underground bunkers.`
 	shipyard "Syndicate Basics"
 		"Barb"
 	outfitter "Syndicate Basics"
@@ -781,12 +777,11 @@ event "capture of Kornephoros"
 		fleet "Large Southern Merchants" 1000
 		fleet "Small Free Worlds" 400
 		fleet "Large Free Worlds" 600
-	planet "Clink"
+	planet Clink
 		description `The mining outpost is swarming with Navy guards; they seem to have turned this moon into a temporary base of operations. The mine has been shut down, and no one is being allowed in or out of the mining outpost. It is not clear whether the miners are prisoners, or merely under a very tight watch.`
 		security 1
-	planet "Deep"
-		spaceport `The spaceport is built on a large island, a now-extinct volcano with an elevation of several kilometers at its center. Most of the large-scale fishing here is done by a single company, Poseidon Industries, who also built and maintain the spaceport. Steep winding roads and sturdy cement homes and warehouses line the mountain slopes, and below you in the harbor several massive trawling vessels are moored. On the outskirts of the spaceport are the ramshackle houses and open-air marketplace used by the smaller, independent fishing families.`
-		spaceport `	There are hundreds of Navy officers patrolling this small spaceport, looking for any signs of local resistance.`
+	planet Deep
+		add spaceport `	There are hundreds of Navy officers patrolling this small spaceport, looking for any signs of local resistance.`
 		security 1
 
 
@@ -830,11 +825,11 @@ event "recapture of Kornephoros"
 		fleet "Small Free Worlds" 900
 		fleet "Large Free Worlds" 1700
 		fleet "Human Miners" 3000
-	planet "Clink"
+	planet Clink
 		description `About a decade ago, a mining corporation from Zug planted a colony on Clink for harvesting some rare earth minerals that are present in this moon's crust due to its unusually high rate of asteroid impacts. The atmosphere here is too thin to breathe without a respirator, and because of the low gravity, the dust raised by the mining operations hangs perpetually in the air.`
 		description `The miners who work here are a tight-knit group, since most of them were part of the original colonization team. They are not particularly open to outsiders, and the facilities here are so rudimentary that they do not even stock fuel for visiting ships.`
 		security .5
-	planet "Deep"
+	planet Deep
 		spaceport `The spaceport is built on a large island, a now-extinct volcano with an elevation of several kilometers at its center. Most of the large-scale fishing here is done by a single company, Poseidon Industries, who also built and maintain the spaceport. Steep winding roads and sturdy cement homes and warehouses line the mountain slopes, and below you in the harbor several massive trawling vessels are moored. On the outskirts of the spaceport are the ramshackle houses and open-air marketplace used by the smaller, independent fishing families.`
 		security .5
 
@@ -915,8 +910,7 @@ event "oathkeepers founded"
 		fleet "Large Oathkeeper" 6000
 		fleet "Small Northern Merchants" 6000
 	planet Farpoint
-		description `Farpoint, on the northernmost end of human space, is a rocky desert planet home to a Republic Navy base and not much else. Farming is possible only within greenhouses, and this system is too far from the galactic center to be desirable for trade or industry.`
-		description `	Lately the Navy base on Farpoint is growing, because it has become the new home of the Navy Oathkeepers, a small branch of the Navy that has sworn to stay uninvolved in the conflict with the Free Worlds.`
+		add description `	Lately the Navy base on Farpoint is growing, because it has become the new home of the Navy Oathkeepers, a small branch of the Navy that has sworn to stay uninvolved in the conflict with the Free Worlds.`
 
 
 
@@ -951,8 +945,8 @@ event "fw conservatory founded"
 		fleet "Large Free Worlds" 1500
 		fleet "Human Miners" 1600
 	planet Winter
-		description `The dense clouds in Winter's atmosphere block out much of the sunlight, creating a frigid landscape below. The planet was not settled until about a century ago, when a group of investors from Pherkad decided to build a manufacturing center here, rather than trying to find more land on the already overcrowded planet of Solace. Claiming that the industrial emissions of carbon dioxide and other greenhouse gases would eventually warm the planet and turn it into a tropical paradise, they were able to draw enough settlers to keep the factories going.`
-		description `	Winter is home to the Free Worlds Conservatory, a new university that is focused on making terraforming technology and expertise available at a reasonable price, as well as on ecological protection and renewal.`
+		add attributes research
+		add description `	Winter is home to the Free Worlds Conservatory, a new university that is focused on making terraforming technology and expertise available at a reasonable price, as well as on ecological protection and renewal.`
 		security .4
 
 
@@ -1064,8 +1058,7 @@ event "fw gets catalytic ramscoop"
 
 event "terraforming Rand"
 	planet Rand
-		description `Rand is a desert world, too dry for much farming and with gravity low enough to be uncomfortable for most human beings. It is, however, the best source of heavy metals in the galactic south. Aside from the managers of the mining companies, nearly all the people here are migrant workers from elsewhere in the Dirt Belt, who have come to spend a season working for the relatively high wages that uranium mining offers, either to send money off-world or to save it up in order to build a better life for themselves.`
-		description `	Recent terraforming experiments have caused an increase in precipitation. Flash floods have scoured the landscape in some areas, but sandstorms are also less frequent, and the locals say the heat is a bit less oppressive than it used to be.`
+		add description `	Recent terraforming experiments have caused an increase in precipitation. Flash floods have scoured the landscape in some areas, but sandstorms are also less frequent, and the locals say the heat is a bit less oppressive than it used to be.`
 
 
 
@@ -1218,8 +1211,7 @@ event "fw southern expansion"
 		fleet "Small Republic" 400
 		fleet "Large Republic" 500
 	planet "New Iceland"
-		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds.`
-		description `	In the wake of their defeat in the south, the Navy has begun to set up a massive new base here on New Iceland, in order to allow them to continue to have a strong presence in this sector.`
+		add description `	In the wake of their defeat in the south, the Navy has begun to set up a massive new base here on New Iceland, in order to allow them to continue to have a strong presence in this sector.`
 
 
 
@@ -2134,7 +2126,7 @@ event "fwc capture kaus borealis"
 		fleet "Large Free Worlds" 400
 		fleet "Large Republic" 2000
 	planet "New Iceland"
-		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds.`
+		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds. Many of the inhabitants wear dust masks to avoid letting the particulate matter from the volcanoes accumulate in their lungs.`
 
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -1968,8 +1968,13 @@ event "at war with the pug"
 			"Syndicate" -.01
 			"Syndicate (Extremist)" -.01
 	system "Delta Capricorni"
-		fleet "Small Core Merchants" 1500
-		fleet "Human Miners" 6000
+		remove fleet "Small Core Merchants"
+		remove fleet "Large Core Merchants"
+		remove fleet "Small Pug"
+		remove fleet "Large Pug"
+		remove fleet "Human Miners"
+		add fleet "Small Core Merchants" 1500
+		add fleet "Human Miners" 6000
 
 
 
@@ -1982,11 +1987,10 @@ event "battle for delta capricorni"
 event "reconnected delta capricorni"
 	link "Delta Capricorni" Markab
 	system "Delta Capricorni"
-		fleet "Small Core Merchants" 1500
-		fleet "Large Core Merchants" 3000
-		fleet "Small Pug" 2000
-		fleet "Large Syndicate" 400
-		fleet "Human Miners" 3000
+		add fleet "Large Core Merchants" 3000
+		add fleet "Small Pug" 2000
+		add fleet "Large Syndicate" 400
+		add fleet "Human Miners" 6000
 
 
 
@@ -1999,10 +2003,10 @@ event "battle for altair"
 event "liberation of altair"
 	system Altair
 		government Republic
-		fleet "Small Core Merchants" 1000
-		fleet "Large Core Merchants" 2000
-		fleet "Small Pug" 2000
-		fleet "Large Syndicate" 800
+		add fleet "Small Core Merchants" 3000
+		add fleet "Large Core Merchants" 2000
+		add fleet "Small Pug" 2000
+		add fleet "Large Syndicate" 800
 
 
 
@@ -2010,8 +2014,10 @@ event "reconnected altair"
 	link Altair Sol
 	system Altair
 		government Republic
-		fleet "Small Core Merchants" 800
-		fleet "Large Core Merchants" 1200
+		remove fleet "Small Pug"
+		remove fleet "Large Syndicate"
+		add fleet "Small Core Merchants" 4000
+		add fleet "Large Core Merchants" 3000
 
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -162,101 +162,147 @@ mission "event: war begins"
 event "initial deployment 1"
 	date 24 7 3014
 	system Spica
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 1700
-		fleet "Small Free Worlds" 800
-		fleet "Large Free Worlds" 1500
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 4800
+		add fleet "Large Southern Merchants" 3923
+		add fleet "Small Free Worlds" 800
+		add fleet "Large Free Worlds" 1500
 	system Minkar
-		fleet "Small Southern Merchants" 700
-		fleet "Large Southern Merchants" 1500
-		fleet "Small Free Worlds" 700
-		fleet "Large Free Worlds" 1200
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 3150
+		add fleet "Large Southern Merchants" 3000
+		add fleet "Small Free Worlds" 700
+		add fleet "Large Free Worlds" 1200
 	system Mimosa
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 2300
-		fleet "Small Free Worlds" 1200
-		fleet "Large Free Worlds" 1900
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 4800
+		add fleet "Large Southern Merchants" 4259
+		add fleet "Small Free Worlds" 1200
+		add fleet "Large Free Worlds" 1900
 	system Kraz
-		fleet "Small Southern Merchants" 900
-		fleet "Large Southern Merchants" 1600
-		fleet "Small Free Worlds" 700
-		fleet "Large Free Worlds" 900
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		add fleet "Small Southern Merchants" 9000
+		add fleet "Large Southern Merchants" 8000
+		add fleet "Small Free Worlds" 700
+		add fleet "Large Free Worlds" 900
 	system Acrux
-		fleet "Small Southern Merchants" 500
-		fleet "Large Southern Merchants" 800
-		fleet "Small Free Worlds" 700
-		fleet "Large Free Worlds" 1100
-		fleet "Human Miners" 5000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 3000
+		add fleet "Large Southern Merchants" 4000
+		add fleet "Small Free Worlds" 700
+		add fleet "Large Free Worlds" 1100
 	
 	system "Tania Australis"
-		fleet "Small Northern Merchants" 1400
-		fleet "Large Northern Merchants" 2900
-		fleet "Small Republic" 600
-		fleet "Large Republic" 400
-		fleet "Navy Surveillance" 2000
+		remove fleet "Small Northern Pirates"
+		remove fleet "Large Northern Pirates"
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		add fleet "Small Northern Merchants" 1400
+		add fleet "Large Northern Merchants" 2900
+		add fleet "Small Republic" 750
+		add fleet "Large Republic" 400
+		add fleet "Navy Surveillance" 2000
 	planet Ingot
 		add description `Ingot is also now home to a burgeoning Navy base, although since the planet is so unlivable most of the troops are just living in ships in orbit.`
 	system Fala
-		fleet "Small Northern Merchants" 1900
-		fleet "Large Northern Merchants" 3500
-		fleet "Small Republic" 600
-		fleet "Large Republic" 400
-		fleet "Small Northern Pirates" 4000
-		fleet "Large Northern Pirates" 8000
-		fleet "Navy Surveillance" 2000
-		fleet "Human Miners" 3000
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		remove fleet "Small Northern Pirates"
+		remove fleet "Large Northern Pirates"
+		remove fleet "Human Miners"
+		add fleet "Small Northern Merchants" 1900
+		add fleet "Large Northern Merchants" 3500
+		add fleet "Small Republic" 705
+		add fleet "Large Republic" 400
+		add fleet "Small Northern Pirates" 4000
+		add fleet "Large Northern Pirates" 8000
+		add fleet "Navy Surveillance" 2000
+		add fleet "Human Miners" 3000
 	system Phecda
-		fleet "Small Northern Merchants" 900
-		fleet "Small Southern Merchants" 1100
-		fleet "Small Republic" 900
-		fleet "Large Republic" 1100
-		fleet "Navy Surveillance" 2000
-		fleet "Human Miners" 3000
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		add fleet "Small Northern Merchants" 900
+		add fleet "Small Southern Merchants" 1100
+		add fleet "Small Republic" 1097
+		add fleet "Large Republic" 1100
+		add fleet "Navy Surveillance" 2000
+		add fleet "Human Miners" 3000
 	system Algorel
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 1200
-		fleet "Small Republic" 700
-		fleet "Large Republic" 500
-		fleet "Small Southern Pirates" 2500
-		fleet "Large Southern Pirates" 8000
-		fleet "Navy Surveillance" 2000
+		remove fleet "Small Militia"
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 800
+		add fleet "Large Southern Merchants" 1200
+		add fleet "Small Republic" 913
+		add fleet "Large Republic" 500
+		add fleet "Small Southern Pirates" 2500
+		add fleet "Large Southern Pirates" 8000
+		add fleet "Navy Surveillance" 2000
 	planet "New Wales"
 		add description `The Republic Navy has planted a base on New Wales: so far, just a densely packed cluster of prefabricated barracks and infirmary buildings on the outskirts of one of the mining colonies.`
 	system Porrima
-		fleet "Small Southern Merchants" 1400
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Republic" 1200
-		fleet "Large Republic" 1800
-		fleet "Small Southern Pirates" 9000
-		fleet "Navy Surveillance" 2000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		add fleet "Small Southern Merchants" 1400
+		add fleet "Large Southern Merchants" 4000
+		add fleet "Small Republic" 1411
+		add fleet "Large Republic" 1800
+		add fleet "Small Southern Pirates" 9000
+		add fleet "Navy Surveillance" 2000
 	system Ipsing
-		fleet "Small Southern Merchants" 2800
-		fleet "Large Southern Merchants" 7000
-		fleet "Small Republic" 2500
-		fleet "Large Republic" 4000
-		fleet "Small Southern Pirates" 5000
-		fleet "Navy Surveillance" 2000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		add fleet "Small Southern Merchants" 2800
+		add fleet "Large Southern Merchants" 7000
+		add fleet "Small Republic" 2500
+		add fleet "Large Republic" 4000
+		add fleet "Small Southern Pirates" 5000
+		add fleet "Navy Surveillance" 2000
 	system Mizar
-		fleet "Small Southern Merchants" 1400
-		fleet "Large Southern Merchants" 4500
-		fleet "Small Republic" 1000
-		fleet "Large Republic" 1400
-		fleet "Small Southern Pirates" 9000
-		fleet "Navy Surveillance" 2000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		add fleet "Small Southern Merchants" 1400
+		add fleet "Large Southern Merchants" 4500
+		add fleet "Small Republic" 1000
+		add fleet "Large Republic" 1400
+		add fleet "Small Southern Pirates" 9000
+		add fleet "Navy Surveillance" 2000
 	system Muphrid
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 4800
-		fleet "Small Republic" 1100
-		fleet "Large Republic" 1900
-		fleet "Small Southern Pirates" 9000
-		fleet "Navy Surveillance" 2000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		add fleet "Small Southern Merchants" 1200
+		add fleet "Large Southern Merchants" 4800
+		add fleet "Small Republic" 1410
+		add fleet "Large Republic" 1900
+		add fleet "Small Southern Pirates" 9000
+		add fleet "Navy Surveillance" 2000
 	system Menkent
-		fleet "Small Southern Merchants" 700
-		fleet "Large Southern Merchants" 1900
-		fleet "Small Republic" 500
-		fleet "Large Republic" 600
-		fleet "Navy Surveillance" 2000
-		fleet "Human Miners" 2000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		add fleet "Small Southern Merchants" 700
+		add fleet "Large Southern Merchants" 1900
+		add fleet "Small Republic" 600
+		add fleet "Large Republic" 600
+		add fleet "Navy Surveillance" 2000
 	planet "New Austria"
 		add description `The Navy has recently requisitioned one of the abandoned mining towns and begun refurbishing it for a secure military base, with the mining tunnels used as deep underground bunkers.`
 	shipyard "Syndicate Basics"

--- a/data/events.txt
+++ b/data/events.txt
@@ -38,6 +38,7 @@ event "war begins"
 		fleet "Large Southern Merchants" 1400
 		fleet "Small Free Worlds" 600
 		fleet "Large Free Worlds" 1300
+		fleet "Human Miners" 4000
 	system Spica
 		government "Free Worlds"
 	system Minkar
@@ -107,6 +108,7 @@ event "war begins"
 		fleet "Large Northern Merchants" 4000
 		fleet "Small Republic" 900
 		fleet "Large Republic" 1000
+		fleet "Human Miners" 6250
 	system Denebola
 		fleet "Small Northern Merchants" 1000
 		fleet "Large Northern Merchants" 3000
@@ -191,12 +193,14 @@ event "initial deployment 1"
 		fleet "Small Northern Pirates" 4000
 		fleet "Large Northern Pirates" 8000
 		fleet "Navy Surveillance" 2000
+		fleet "Human Miners" 3000
 	system Phecda
 		fleet "Small Northern Merchants" 900
 		fleet "Small Southern Merchants" 1100
 		fleet "Small Republic" 900
 		fleet "Large Republic" 1100
 		fleet "Navy Surveillance" 2000
+		fleet "Human Miners" 3000
 	system Algorel
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 1200
@@ -277,6 +281,7 @@ event "initial deployment 2"
 		fleet "Large Free Worlds" 10000
 		fleet "Small Southern Pirates" 4000
 		fleet "Large Southern Pirates" 8000
+		fleet "Human Miners" 3000
 	system Zubeneschamali
 		fleet "Small Southern Merchants" 500
 		fleet "Large Southern Merchants" 1000
@@ -284,6 +289,7 @@ event "initial deployment 2"
 		fleet "Large Free Worlds" 2400
 		fleet "Small Southern Pirates" 4000
 		fleet "Large Southern Pirates" 5000
+		fleet "Human Miners" 1750
 	system Kochab
 		fleet "Small Southern Merchants" 1800
 		fleet "Large Southern Merchants" 5000
@@ -305,6 +311,7 @@ event "initial deployment 2"
 		fleet "Small Republic" 1000
 		fleet "Large Republic" 2000
 		fleet "Navy Surveillance" 1600
+		fleet "Human Miners" 4000
 	system "Delta Velorum"
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 3000
@@ -313,6 +320,7 @@ event "initial deployment 2"
 		fleet "Small Republic" 1600
 		fleet "Large Republic" 2400
 		fleet "Navy Surveillance" 1600
+		fleet "Human Miners" 2000
 	system Turais
 		fleet "Small Southern Merchants" 2000
 		fleet "Large Southern Merchants" 6000
@@ -321,6 +329,7 @@ event "initial deployment 2"
 		fleet "Small Republic" 1000
 		fleet "Large Republic" 1800
 		fleet "Navy Surveillance" 1600
+		fleet "Human Miners" 2000
 	system Gacrux
 		fleet "Small Southern Merchants" 2000
 		fleet "Large Southern Merchants" 5000
@@ -336,6 +345,7 @@ event "initial deployment 2"
 		fleet "Small Republic" 1200
 		fleet "Large Republic" 1800
 		fleet "Navy Surveillance" 1600
+		fleet "Human Miners" 3000
 	system Muhlifain
 		fleet "Small Southern Merchants" 1000
 		fleet "Large Southern Merchants" 3500
@@ -361,7 +371,7 @@ event "initial deployment 2"
 		fleet "Navy Surveillance" 1600
 	system Alioth
 		fleet "Small Southern Merchants" 400
-		fleet "Large Northern Merchants" 600
+		fleet "Large Southern Merchants" 600
 		fleet "Small Southern Pirates" 1200
 		fleet "Large Southern Pirates" 2400
 		fleet "Small Republic" 3000
@@ -381,6 +391,7 @@ event "initial deployment 2"
 		fleet "Small Republic" 2000
 		fleet "Large Republic" 3000
 		fleet "Navy Surveillance" 1600
+		fleet "Human Miners" 5000
 	system Rutilicus
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 2000
@@ -388,20 +399,22 @@ event "initial deployment 2"
 		fleet "Small Republic" 1000
 		fleet "Large Republic" 2000
 		fleet "Navy Surveillance" 1600
+		fleet "Human Miners" 3000
 	system Alphecca
 		fleet "Small Southern Merchants" 2000
-		fleet "Large Northern Merchants" 3500
+		fleet "Large Southern Merchants" 3500
 		fleet "Small Southern Pirates" 3000
 		fleet "Small Republic" 3000
 		fleet "Large Republic" 4000
 		fleet "Navy Surveillance" 1600
 	system Boral
 		fleet "Small Southern Merchants" 3000
-		fleet "Large Northern Merchants" 8000
+		fleet "Large Southern Merchants" 8000
 		fleet "Small Southern Pirates" 1500
 		fleet "Small Republic" 7000
 		fleet "Large Republic" 12000
 		fleet "Navy Surveillance" 1600
+		fleet "Human Miners" 2000
 	system Cebalrai
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 2000
@@ -433,6 +446,7 @@ event "initial deployment 3"
 		fleet "Small Southern Pirates" 3000
 		fleet "Small Free Worlds" 3000
 		fleet "Large Free Worlds" 6000
+		fleet "Human Miners" 3000
 	system Sabik
 		fleet "Small Southern Merchants" 400
 		fleet "Large Southern Merchants" 600
@@ -445,6 +459,7 @@ event "initial deployment 3"
 		fleet "Large Free Worlds" 700
 		fleet "Small Southern Pirates" 1400
 		fleet "Large Southern Pirates" 3000
+		fleet "Human Miners" 3000
 	system Kornephoros
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 700
@@ -674,6 +689,7 @@ event "initial deployment 4"
 		fleet "Small Free Worlds" 2000
 		fleet "Large Free Worlds" 3000
 		fleet "Navy Surveillance" 800
+		fleet "Human Miners" 2000
 	system Lesath
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 1600
@@ -689,6 +705,7 @@ event "initial deployment 4"
 		fleet "Large Southern Pirates" 8000
 		fleet "Small Free Worlds" 1000
 		fleet "Large Free Worlds" 2100
+		fleet "Human Miners" 2000
 	system Alniyat
 		fleet "Small Southern Merchants" 500
 		fleet "Large Southern Merchants" 600
@@ -716,13 +733,15 @@ event "initial deployment 4"
 		fleet "Large Southern Pirates" 1600
 		fleet "Small Free Worlds" 4000
 		fleet "Large Free Worlds" 8000
+		fleet "Human Miners" 3000
 	system "Yed Prior"
-		fleet "Small Northern Merchants" 800
-		fleet "Large Northern Merchants" 1100
+		fleet "Small Southern Merchants" 800
+		fleet "Large Southern Merchants" 1100
 		fleet "Small Southern Pirates" 1000
 		fleet "Large Southern Pirates" 2000
 		fleet "Small Free Worlds" 5000
 		fleet "Large Free Worlds" 8000
+		fleet "Human Miners" 1600
 	system "Kappa Centauri"
 		fleet "Small Southern Merchants" 900
 		fleet "Large Southern Merchants" 2700
@@ -753,6 +772,7 @@ event "initial deployment 4"
 		fleet "Small Southern Pirates" 1400
 		fleet "Large Southern Pirates" 3000
 		fleet "Navy Surveillance" 800
+		fleet "Human Miners" 3000
 	system Kornephoros
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 1000
@@ -772,6 +792,7 @@ event "capture of Kornephoros"
 		fleet "Small Republic" 300
 		fleet "Large Republic" 500
 		fleet "Navy Surveillance" 800
+		fleet "Human Miners" 3000
 	system Sabik
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 1000
@@ -818,6 +839,7 @@ event "recapture of Kornephoros"
 		fleet "Large Southern Merchants" 800
 		fleet "Small Free Worlds" 600
 		fleet "Large Free Worlds" 600
+		fleet "Human Miners" 3000
 	system Kornephoros
 		government "Free Worlds"
 		fleet "Small Southern Merchants" 800
@@ -852,6 +874,7 @@ event "oathkeepers founded"
 		fleet "Large Oathkeeper" 4000
 		fleet "Small Northern Pirates" 2000
 		fleet "Large Northern Pirates" 2000
+		fleet "Human Miners" 3000
 	system Mirzam
 		fleet "Small Northern Merchants" 2000
 		fleet "Large Northern Merchants" 2000
@@ -871,6 +894,7 @@ event "oathkeepers founded"
 		fleet "Small Oathkeeper" 1000
 		fleet "Large Oathkeeper" 2000
 		fleet "Large Northern Pirates" 4000
+		fleet "Human Miners" 3000
 	system Rigel
 		fleet "Small Northern Merchants" 2000
 		fleet "Large Northern Merchants" 4000
@@ -878,6 +902,7 @@ event "oathkeepers founded"
 		fleet "Large Oathkeeper" 2000
 		fleet "Small Northern Pirates" 3000
 		fleet "Large Northern Pirates" 5000
+		fleet "Human Miners" 2000
 	system Alnitak
 		fleet "Small Northern Pirates" 3000
 		fleet "Large Northern Pirates" 5000
@@ -895,6 +920,7 @@ event "oathkeepers founded"
 		fleet "Large Northern Pirates" 2000
 		fleet "Large Oathkeeper" 2000
 		fleet "Small Northern Merchants" 4000
+		fleet "Human Miners" 2000
 	system Almaaz
 		fleet "Small Northern Pirates" 500
 		fleet "Large Northern Pirates" 600
@@ -937,8 +963,8 @@ event "plasma turret available"
 
 event "fw conservatory founded"
 	system "Yed Prior"
-		fleet "Small Northern Merchants" 500
-		fleet "Large Northern Merchants" 800
+		fleet "Small Southern Merchants" 500
+		fleet "Large Southern Merchants" 800
 		fleet "Small Southern Pirates" 1200
 		fleet "Large Southern Pirates" 2400
 		fleet "Small Free Worlds" 1000
@@ -1035,6 +1061,7 @@ event "navy occupying the south"
 		fleet "Large Southern Merchants" 1200
 		fleet "Small Republic" 500
 		fleet "Large Republic" 700
+		fleet "Human Miners" 3000
 	system "Delta Sagittarii"
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 4000
@@ -1196,6 +1223,7 @@ event "fw southern expansion"
 		fleet "Small Southern Pirates" 3000
 		fleet "Large Southern Pirates" 7000
 		fleet "Navy Surveillance" 5000
+		fleet "Human Miners" 5500
 	system "Delta Sagittarii"
 		government "Free Worlds"
 		fleet "Small Southern Merchants" 1200
@@ -1205,6 +1233,7 @@ event "fw southern expansion"
 		fleet "Small Southern Pirates" 3000
 		fleet "Large Southern Pirates" 7000
 		fleet "Navy Surveillance" 3000
+		fleet "Human Miners" 4000
 	system "Kaus Borealis"
 		fleet "Small Southern Merchants" 900
 		fleet "Large Southern Merchants" 4000
@@ -1218,7 +1247,7 @@ event "fw southern expansion"
 event "fw occupying the north"
 	system Alioth
 		fleet "Small Southern Merchants" 400
-		fleet "Large Northern Merchants" 600
+		fleet "Large Southern Merchants" 600
 		fleet "Small Free Worlds" 500
 		fleet "Large Free Worlds" 800
 		fleet "Small Republic" 5000
@@ -1226,15 +1255,16 @@ event "fw occupying the north"
 		fleet "Navy Surveillance" 4000
 	system Alphecca
 		fleet "Small Southern Merchants" 2000
-		fleet "Large Northern Merchants" 3500
+		fleet "Large Southern Merchants" 3500
 		fleet "Small Free Worlds" 1200
 		fleet "Large Free Worlds" 2000
 		fleet "Navy Surveillance" 6000
 	system Boral
 		fleet "Small Southern Merchants" 3000
-		fleet "Large Northern Merchants" 8000
+		fleet "Large Southern Merchants" 8000
 		fleet "Small Free Worlds" 1500
 		fleet "Large Free Worlds" 3800
+		fleet "Human Miners" 2000
 	system Seginus
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 2700
@@ -1422,6 +1452,7 @@ event "fw expanded and cut"
 		fleet "Small Republic" 500
 		fleet "Large Republic" 700
 		fleet "Large Free Worlds" 3000
+		fleet "Human Miners" 6000
 	system Rastaban
 		government Republic
 		fleet "Small Southern Merchants" 1000
@@ -1461,6 +1492,7 @@ event "fw at war with Syndicate"
 	system Rutilicus
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 2000
+		fleet "Human Miners" 3000
 	system Cebalrai
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 2000
@@ -1510,6 +1542,7 @@ event "fw armistice"
 		fleet "Large Southern Merchants" 2000
 		fleet "Small Southern Pirates" 8000
 		fleet "Small Republic" 1000
+		fleet "Human Miners" 3000
 	system Cebalrai
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 2000
@@ -1568,6 +1601,7 @@ event "navy out of rastaban"
 		fleet "Small Southern Pirates" 3000
 		fleet "Large Southern Pirates" 7000
 		fleet "Navy Surveillance" 3000
+		fleet "Human Miners" 4000
 	system Lesath
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 1600
@@ -1666,6 +1700,7 @@ event "pug invasion 2"
 		fleet "Large Northern Merchants" 3000
 		fleet "Small Pug" 800
 		fleet "Large Pug" 1200
+		fleet "Human Miners" 5000
 	system Altair
 		government Pug
 		fleet "Small Core Merchants" 400
@@ -1712,6 +1747,7 @@ event "pug invasion 3"
 		fleet "Large Core Merchants" 800
 		fleet "Small Pug" 800
 		fleet "Large Pug" 1100
+		fleet "Human Miners" 3000
 	system Alderamin
 		government Pug
 		fleet "Small Core Merchants" 2000
@@ -1787,6 +1823,7 @@ event "at war with the pug"
 			"Syndicate (Extremist)" -.01
 	system "Delta Capricorni"
 		fleet "Small Core Merchants" 1500
+		fleet "Human Miners" 6000
 
 
 
@@ -1849,6 +1886,7 @@ event "pug flee"
 		fleet "Large Northern Merchants" 3000
 		fleet "Small Republic" 800
 		fleet "Large Republic" 1200
+		fleet "Human Miners" 5000
 	system Altair
 		fleet "Small Core Merchants" 400
 		fleet "Large Core Merchants" 600
@@ -1866,6 +1904,7 @@ event "pug flee"
 		fleet "Large Core Merchants" 800
 		fleet "Small Syndicate" 500
 		fleet "Large Syndicate" 600
+		fleet "Human Miners" 3000
 	system Alderamin
 		fleet "Small Core Merchants" 2000
 		fleet "Large Core Merchants" 3200
@@ -1881,12 +1920,14 @@ event "pug flee"
 		fleet "Large Core Merchants" 600
 		fleet "Small Republic" 1600
 		fleet "Large Republic" 3000
+		fleet "Human Miners" 2000
 	system Nocte
 		fleet "Small Northern Merchants" 1500
 		fleet "Large Northern Merchants" 5000
 		fleet "Small Republic" 3000
 		fleet "Large Republic" 7000
 		fleet "Small Northern Pirates" 2500
+		fleet "Human Miners" 1600
 	system Orvala
 		fleet "Small Southern Merchants" 3000
 		fleet "Large Southern Merchants" 6000
@@ -2074,6 +2115,7 @@ event "fwc southern liberation"
 		fleet "Small Southern Pirates" 3000
 		fleet "Large Southern Pirates" 7000
 		fleet "Large Republic" 3000
+		fleet "Human Miners" 4000
 	system Rastaban
 		government "Free Worlds"
 		fleet "Small Southern Merchants" 1200
@@ -2191,6 +2233,7 @@ event "fwc defended cebalrai"
 		fleet "Large Southern Pirates" 6000
 		fleet "Small Free Worlds" 2000
 		fleet "Large Free Worlds" 3000
+		fleet "Human Miners" 1750
 	system Seginus
 		fleet "Small Southern Merchants" 1200
 		fleet "Large Southern Merchants" 2700
@@ -2216,6 +2259,7 @@ event "fwc defended cebalrai"
 		fleet "Large Free Worlds" 900
 		fleet "Small Southern Pirates" 3000
 		fleet "Large Southern Pirates" 7000
+		fleet "Human Miners" 4000
 	system Rastaban
 		government "Free Worlds"
 		fleet "Small Southern Merchants" 1200
@@ -2317,6 +2361,7 @@ event "fwc pug invasion"
 		fleet "Large Core Merchants" 800
 		fleet "Small Pug" 800
 		fleet "Large Pug" 1100
+		fleet "Human Miners" 3000
 	system Alderamin
 		government Pug
 		fleet "Small Core Merchants" 2000
@@ -2453,12 +2498,14 @@ event "fwc liberation of rasalhague"
 	system Vega
 		fleet "Small Southern Merchants" 1500
 		fleet "Large Southern Merchants" 2000
+		fleet "Human Miners" 5000
 	system Altair
 		fleet "Small Core Merchants" 400
 		fleet "Large Core Merchants" 600
 	system "Delta Capricorni"
 		fleet "Small Core Merchants" 700
 		fleet "Large Core Merchants" 800
+		fleet "Human Miners" 3000
 	system Alderamin
 		fleet "Small Core Merchants" 2000
 		fleet "Large Core Merchants" 3200

--- a/data/events.txt
+++ b/data/events.txt
@@ -1288,21 +1288,13 @@ event "normal in Alnasl"
 
 event "fw southern expansion"
 	system Lesath
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 1600
-		fleet "Small Free Worlds" 800
-		fleet "Large Free Worlds" 1100
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 5000
-		fleet "Navy Surveillance" 4000
+		add fleet "Small Southern Pirates" 2000
+		add fleet "Large Southern Pirates" 5000
+		add fleet "Navy Surveillance" 4000
 	system Sargas
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2500
-		fleet "Small Free Worlds" 1000
-		fleet "Large Free Worlds" 1500
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Navy Surveillance" 5000
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 7000
+		add fleet "Navy Surveillance" 5000
 	system Rastaban
 		government "Free Worlds"
 		fleet "Small Southern Merchants" 1200
@@ -1313,38 +1305,36 @@ event "fw southern expansion"
 		fleet "Large Southern Pirates" 7000
 		fleet "Navy Surveillance" 2000
 	system Girtab
-		fleet "Small Southern Merchants" 900
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Free Worlds" 1000
-		fleet "Large Free Worlds" 1700
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Navy Surveillance" 5000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Free Worlds" 1000
+		add fleet "Large Free Worlds" 1700
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 7000
+		add fleet "Navy Surveillance" 5000
 	system Albaldah
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 1200
-		fleet "Small Free Worlds" 900
-		fleet "Large Free Worlds" 1900
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Navy Surveillance" 5000
-		fleet "Human Miners" 5500
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Free Worlds" 900
+		add fleet "Large Free Worlds" 1900
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 7000
+		add fleet "Navy Surveillance" 5000
 	system "Delta Sagittarii"
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Free Worlds" 600
-		fleet "Large Free Worlds" 900
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Navy Surveillance" 3000
-		fleet "Human Miners" 4000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Free Worlds" 600
+		add fleet "Large Free Worlds" 900
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 7000
+		add fleet "Navy Surveillance" 3000
 	system "Kaus Borealis"
-		fleet "Small Southern Merchants" 900
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Republic" 400
-		fleet "Large Republic" 500
+		remove fleet "Small Southern Pirates"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Republic" 628
+		add fleet "Large Republic" 1333
 	planet "New Iceland"
 		add description `	In the wake of their defeat in the south, the Navy has begun to set up a massive new base here on New Iceland, in order to allow them to continue to have a strong presence in this sector.`
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -1694,48 +1694,64 @@ event "deep sky tech available"
 event "navy out of rastaban"
 	system Rastaban
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 2400
-		fleet "Small Free Worlds" 500
-		fleet "Large Free Worlds" 700
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Navy Surveillance" 2000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Southern Merchants" 1200
+		add fleet "Large Southern Merchants" 2400
+		add fleet "Small Free Worlds" 500
+		add fleet "Large Free Worlds" 1076
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 7000
+		add fleet "Navy Surveillance" 2000
 	system Girtab
 		government Neutral
-		fleet "Small Southern Merchants" 900
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Free Worlds" 1000
-		fleet "Large Free Worlds" 1700
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Navy Surveillance" 5000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Southern Merchants" 9000
+		add fleet "Large Southern Merchants" 6000
+		add fleet "Small Free Worlds" 1000
+		add fleet "Large Free Worlds" 30600
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 7000
+		add fleet "Navy Surveillance" 5000
 	system "Delta Sagittarii"
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Free Worlds" 600
-		fleet "Large Free Worlds" 900
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Navy Surveillance" 3000
-		fleet "Human Miners" 4000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Southern Merchants" 3000
+		add fleet "Large Southern Merchants" 12000
+		add fleet "Small Free Worlds" 600
+		add fleet "Large Free Worlds" 1285
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 7000
+		add fleet "Navy Surveillance" 3000
+		add fleet "Human Miners" 12000
 	system Lesath
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 1600
-		fleet "Small Free Worlds" 800
-		fleet "Large Free Worlds" 1100
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 5000
-		fleet "Navy Surveillance" 4000
+		remove fleet "Large Free Worlds"
+		remove fleet "Large Free Worlds"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Southern Merchants" 923
+		add fleet "Large Southern Merchants" 1945
+		add fleet "Small Free Worlds" 800
+		add fleet "Large Free Worlds" 1100
+		add fleet "Small Southern Pirates" 2000
+		add fleet "Large Southern Pirates" 5000
+		add fleet "Navy Surveillance" 4000
 	system "Alpha Arae"
-		fleet "Small Southern Merchants" 2100
-		fleet "Large Southern Merchants" 8000
-		fleet "Small Southern Pirates" 6000
-		fleet "Large Southern Pirates" 13000
-		fleet "Small Republic" 900
-		fleet "Large Republic" 800
-		fleet "Navy Surveillance" 1200
+		remove fleet "Large Southern Merchants"
+		remove fleet "Large Free Worlds"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Southern Merchants" 3620
+		add fleet "Large Southern Merchants" 8000
+		add fleet "Small Southern Pirates" 6000
+		add fleet "Large Southern Pirates" 13000
+		add fleet "Small Republic" 900
+		add fleet "Large Republic" 800
+		add fleet "Navy Surveillance" 1200
 
 
 
@@ -1751,14 +1767,18 @@ event "stack core for sale"
 
 event "syndicate occupies sol"
 	system Sol
-		fleet "Small Northern Merchants" 500
-		fleet "Large Northern Merchants" 700
-		fleet "Small Republic" 800
-		fleet "Large Republic" 1200
-		fleet "Small Core Merchants" 900
-		fleet "Large Core Merchants" 1400
-		fleet "Small Syndicate" 400
-		fleet "Large Syndicate" 600
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Northern Merchants" 500
+		add fleet "Large Northern Merchants" 700
+		add fleet "Small Republic" 800
+		add fleet "Large Republic" 1200
+		add fleet "Small Core Merchants" 9000
+		add fleet "Large Core Merchants" 4666
+		add fleet "Small Syndicate" 400
+		add fleet "Large Syndicate" 600
 
 
 
@@ -1777,22 +1797,25 @@ event "pug invasion"
 	unvisit Peacock
 	system "Zeta Aquilae"
 		government Pug
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 3000
-		fleet "Small Pug" 1000
-		fleet "Large Pug" 2000
+		add fleet "Small Southern Merchants" 1250
+		add fleet "Large Southern Merchants" 3000
+		add fleet "Small Pug" 1000
+		add fleet "Large Pug" 2000
 	system Rasalhague
 		government Pug
-		fleet "Small Southern Merchants" 1500
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Pug" 800
-		fleet "Large Pug" 2000
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Pug" 800
+		add fleet "Large Pug" 2000
 	system Orvala
 		government Pug
-		fleet "Small Southern Merchants" 3000
-		fleet "Large Southern Merchants" 6000
-		fleet "Small Pug" 5000
-		fleet "Large Pug" 9000
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Pug" 5000
+		add fleet "Large Pug" 9000
 	planet Rand
 		security 0
 	planet Oblivion
@@ -1814,32 +1837,33 @@ event "pug invasion 2"
 	unvisit Markab
 	system Vega
 		government Pug
-		fleet "Small Northern Merchants" 800
-		fleet "Large Northern Merchants" 3000
-		fleet "Small Pug" 800
-		fleet "Large Pug" 1200
-		fleet "Human Miners" 5000
+		remove fleet "Small Republic"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Northern Merchants" 4000
+		add fleet "Large Northern Merchants" 12000
+		add fleet "Small Pug" 800
+		add fleet "Large Pug" 1200
 	system Altair
 		government Pug
-		fleet "Small Core Merchants" 400
-		fleet "Large Core Merchants" 600
-		fleet "Small Northern Merchants" 1000
-		fleet "Large Northern Merchants" 3000
-		fleet "Small Pug" 700
-		fleet "Large Pug" 900
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Pug" 700
+		add fleet "Large Pug" 900
 	system Fomalhaut
 		government Pug
-		fleet "Small Core Merchants" 1000
-		fleet "Large Core Merchants" 1200
-		fleet "Small Pug" 1400
-		fleet "Large Pug" 2000
+		remove fleet "Small Syndicate"
+		remove fleet "Large Syndicate"
+		add fleet "Small Pug" 1400
+		add fleet "Large Pug" 2000
 	system Nocte
 		government Pug
-		fleet "Small Northern Merchants" 1500
-		fleet "Large Northern Merchants" 5000
-		fleet "Small Pug" 3000
-		fleet "Large Pug" 7000
-		fleet "Human Miners" 1600
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Small Northern Pirates"
+		add fleet "Small Pug" 3000
+		add fleet "Large Pug" 7000
 	planet Silver
 		security 0
 	planet Shiver
@@ -1861,17 +1885,18 @@ event "pug invasion 3"
 	unvisit Alnair
 	system "Delta Capricorni"
 		government Pug
-		fleet "Small Core Merchants" 700
-		fleet "Large Core Merchants" 800
-		fleet "Small Pug" 800
-		fleet "Large Pug" 1100
-		fleet "Human Miners" 3000
+		remove fleet "Small Syndicate"
+		remove fleet "Large Syndicate"
+		add fleet "Small Pug" 800
+		add fleet "Large Pug" 1100
 	system Alderamin
 		government Pug
-		fleet "Small Core Merchants" 2000
-		fleet "Large Core Merchants" 3200
-		fleet "Small Pug" 1200
-		fleet "Large Pug" 2500
+		remove fleet "Small Syndicate"
+		remove fleet "Large Syndicate"
+		remove fleet "Small Core Pirates"
+		remove fleet "Large Core Pirates"
+		add fleet "Small Pug" 1200
+		add fleet "Large Pug" 2500
 	planet Maker
 		security 0
 	planet Furnace

--- a/data/events.txt
+++ b/data/events.txt
@@ -315,178 +315,156 @@ event "initial deployment 2"
 	planet Martini
 		"required reputation" 10
 	system Izar
-		fleet "Small Southern Merchants" 500
-		fleet "Large Southern Merchants" 1500
-		fleet "Small Free Worlds" 700
-		fleet "Large Free Worlds" 1000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		add fleet "Small Southern Merchants" 1750
+		add fleet "Large Southern Merchants" 9000
+		add fleet "Small Free Worlds" 700
+		add fleet "Large Free Worlds" 1000
 	system "Zeta Centauri"
-		fleet "Small Southern Merchants" 700
-		fleet "Large Southern Merchants" 1700
-		fleet "Small Free Worlds" 1200
-		fleet "Large Free Worlds" 2000
-		fleet "Small Southern Pirates" 6000
-		fleet "Large Southern Pirates" 9000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 5600
+		add fleet "Large Southern Merchants" 11333
+		add fleet "Small Free Worlds" 1200
+		add fleet "Large Free Worlds" 2000
+		add fleet "Small Southern Pirates" 6000
+		add fleet "Large Southern Pirates" 9000
 	system Hadar
-		fleet "Small Southern Merchants" 400
-		fleet "Large Southern Merchants" 600
-		fleet "Small Free Worlds" 600
-		fleet "Large Free Worlds" 1100
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Large Southern Merchants" 1500
+		add fleet "Small Free Worlds" 600
+		add fleet "Large Free Worlds" 1100
 	system Alkaid
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Free Worlds" 6000
-		fleet "Large Free Worlds" 10000
-		fleet "Small Southern Pirates" 4000
-		fleet "Large Southern Pirates" 8000
-		fleet "Human Miners" 3000
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 4800
+		add fleet "Large Southern Merchants" 20000
+		add fleet "Small Free Worlds" 6000
+		add fleet "Large Free Worlds" 10000
+		add fleet "Small Southern Pirates" 4000
+		add fleet "Large Southern Pirates" 8000
 	system Zubeneschamali
-		fleet "Small Southern Merchants" 500
-		fleet "Large Southern Merchants" 1000
-		fleet "Small Free Worlds" 1400
-		fleet "Large Free Worlds" 2400
-		fleet "Small Southern Pirates" 4000
-		fleet "Large Southern Pirates" 5000
-		fleet "Human Miners" 1750
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Large Southern Merchants" 3000
+		add fleet "Small Free Worlds" 1400
+		add fleet "Large Free Worlds" 2400
+		add fleet "Small Southern Pirates" 4000
+		add fleet "Large Southern Pirates" 5000
 	system Kochab
-		fleet "Small Southern Merchants" 1800
-		fleet "Large Southern Merchants" 5000
-		fleet "Small Southern Pirates" 6000
-		fleet "Small Free Worlds" 5000
+		remove fleet "Small Militia"
+		remove fleet "Small Southern Pirates"
+		add fleet "Small Southern Merchants" 18000
+		add fleet "Large Southern Merchants" 30000
+		add fleet "Small Free Worlds" 5000
+		add fleet "Small Southern Pirates" 6000
 	system Ildaria
-		fleet "Small Southern Merchants" 900
-		fleet "Large Southern Merchants" 1800
-		fleet "Small Free Worlds" 2200
-		fleet "Large Free Worlds" 3600
-		fleet "Small Southern Pirates" 4000
-		fleet "Large Southern Pirates" 7000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 9000
+		add fleet "Large Southern Merchants" 18000
+		add fleet "Small Free Worlds" 2200
+		add fleet "Large Free Worlds" 3600
+		add fleet "Small Southern Pirates" 4000
+		add fleet "Large Southern Pirates" 7000
 	
 	system Mora
-		fleet "Small Southern Merchants" 2800
-		fleet "Large Southern Merchants" 5000
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 4000
-		fleet "Small Republic" 1000
-		fleet "Large Republic" 2000
-		fleet "Navy Surveillance" 1600
-		fleet "Human Miners" 4000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Human Miners"
+		add fleet "Small Southern Merchants" 2800
+		add fleet "Large Southern Merchants" 5000
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Large Southern Pirates" 4000
+		add fleet "Small Republic" 1052
+		add fleet "Large Republic" 2000
+		add fleet "Navy Surveillance" 1600
+		add fleet "Human Miners" 4000
 	system "Delta Velorum"
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 3000
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 5000
-		fleet "Small Republic" 1600
-		fleet "Large Republic" 2400
-		fleet "Navy Surveillance" 1600
-		fleet "Human Miners" 2000
+		add fleet "Small Republic" 1846
+		add fleet "Large Republic" 2400
+		add fleet "Navy Surveillance" 1600
 	system Turais
-		fleet "Small Southern Merchants" 2000
-		fleet "Large Southern Merchants" 6000
-		fleet "Small Southern Pirates" 3000
-		fleet "Large Southern Pirates" 7000
-		fleet "Small Republic" 1000
-		fleet "Large Republic" 1800
-		fleet "Navy Surveillance" 1600
-		fleet "Human Miners" 2000
+		add fleet "Small Republic" 1000
+		add fleet "Large Republic" 1800
+		add fleet "Navy Surveillance" 1600
 	system Gacrux
-		fleet "Small Southern Merchants" 2000
-		fleet "Large Southern Merchants" 5000
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 4000
-		fleet "Small Republic" 2000
-		fleet "Large Republic" 3000
-		fleet "Navy Surveillance" 1600
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Pirates" 2000
+		add fleet "Large Southern Pirates" 4000
+		add fleet "Small Republic" 2307
+		add fleet "Large Republic" 3000
+		add fleet "Navy Surveillance" 1600
 	system "Cor Caroli"
-		fleet "Small Southern Merchants" 700
-		fleet "Large Southern Merchants" 1300
-		fleet "Small Southern Pirates" 2000
-		fleet "Small Republic" 1200
-		fleet "Large Republic" 1800
-		fleet "Navy Surveillance" 1600
-		fleet "Human Miners" 3000
+		add fleet "Small Republic" 1363
+		add fleet "Large Republic" 1800
+		add fleet "Navy Surveillance" 1600
 	system Muhlifain
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 3500
-		fleet "Small Southern Pirates" 6000
-		fleet "Small Republic" 3000
-		fleet "Large Republic" 4000
-		fleet "Navy Surveillance" 1600
+		add fleet "Small Republic" 3000
+		add fleet "Large Republic" 4000
+		add fleet "Navy Surveillance" 1600
 	system Vindemiatrix
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 3000
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 4000
-		fleet "Small Republic" 2000
-		fleet "Large Republic" 3000
-		fleet "Navy Surveillance" 1600
+		add fleet "Small Republic" 2000
+		add fleet "Large Republic" 3000
+		add fleet "Navy Surveillance" 1600
 	system Sarin
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 3000
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 6000
-		fleet "Small Republic" 8000
-		fleet "Large Republic" 15000
-		fleet "Navy Surveillance" 1600
+		add fleet "Small Republic" 8000
+		add fleet "Large Republic" 15000
+		add fleet "Navy Surveillance" 1600
 	system Alioth
-		fleet "Small Southern Merchants" 400
-		fleet "Large Southern Merchants" 600
-		fleet "Small Southern Pirates" 1200
-		fleet "Large Southern Pirates" 2400
-		fleet "Small Republic" 3000
-		fleet "Large Republic" 4000
-		fleet "Navy Surveillance" 1600
+		remove fleet "Small Militia"
+		add fleet "Small Republic" 3000
+		add fleet "Large Republic" 4000
+		add fleet "Navy Surveillance" 1600
 	system Holeb
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 3000
-		fleet "Small Southern Pirates" 5000
-		fleet "Small Republic" 2000
-		fleet "Large Republic" 3000
-		fleet "Navy Surveillance" 1600
+		remove fleet "Small Militia"
+		add fleet "Small Republic" 2000
+		add fleet "Large Republic" 3000
+		add fleet "Navy Surveillance" 1600
 	system Arcturus
-		fleet "Small Southern Merchants" 700
-		fleet "Large Southern Merchants" 3000
-		fleet "Small Southern Pirates" 4000
-		fleet "Small Republic" 2000
-		fleet "Large Republic" 3000
-		fleet "Navy Surveillance" 1600
-		fleet "Human Miners" 5000
+		remove fleet "Small Militia"
+		add fleet "Small Southern Pirates" 4000
+		add fleet "Small Republic" 2000
+		add fleet "Large Republic" 3000
+		add fleet "Navy Surveillance" 1600
 	system Rutilicus
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Southern Pirates" 8000
-		fleet "Small Republic" 1000
-		fleet "Large Republic" 2000
-		fleet "Navy Surveillance" 1600
-		fleet "Human Miners" 3000
+		remove fleet "Small Militia"
+		add fleet "Small Southern Pirates" 8000
+		add fleet "Small Republic" 1000
+		add fleet "Large Republic" 2000
+		add fleet "Navy Surveillance" 1600
 	system Alphecca
-		fleet "Small Southern Merchants" 2000
-		fleet "Large Southern Merchants" 3500
-		fleet "Small Southern Pirates" 3000
-		fleet "Small Republic" 3000
-		fleet "Large Republic" 4000
-		fleet "Navy Surveillance" 1600
+		remove fleet "Small Militia"
+		add fleet "Small Republic" 3000
+		add fleet "Large Republic" 4000
+		add fleet "Navy Surveillance" 1600
 	system Boral
-		fleet "Small Southern Merchants" 3000
-		fleet "Large Southern Merchants" 8000
-		fleet "Small Southern Pirates" 1500
-		fleet "Small Republic" 7000
-		fleet "Large Republic" 12000
-		fleet "Navy Surveillance" 1600
-		fleet "Human Miners" 2000
+		remove fleet "Small Militia"
+		add fleet "Small Republic" 7000
+		add fleet "Large Republic" 12000
+		add fleet "Navy Surveillance" 1600
 	system Cebalrai
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Southern Pirates" 4000
-		fleet "Small Republic" 1000
-		fleet "Large Republic" 2000
-		fleet "Navy Surveillance" 1600
+		remove fleet "Small Militia"
+		add fleet "Small Republic" 1000
+		add fleet "Large Republic" 2000
+		add fleet "Navy Surveillance" 1600
 	system Rasalhague
-		fleet "Small Southern Merchants" 1500
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Southern Pirates" 4000
-		fleet "Large Southern Pirates" 8000
-		fleet "Small Republic" 3000
-		fleet "Large Republic" 4000
-		fleet "Navy Surveillance" 1600
+		add fleet "Small Republic" 3000
+		add fleet "Large Republic" 4000
+		add fleet "Navy Surveillance" 1600
 
 event "initial deployment 3"
 	date 29 8 3014

--- a/data/events.txt
+++ b/data/events.txt
@@ -2442,52 +2442,54 @@ event "fwc pug invasion"
 			"Free Worlds" -.01
 	system "Zeta Aquilae"
 		government Pug
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 3000
-		fleet "Small Pug" 1000
-		fleet "Large Pug" 2000
+		add fleet "Small Southern Merchants" 1250
+		add fleet "Large Southern Merchants" 3000
+		add fleet "Small Pug" 1000
+		add fleet "Large Pug" 2000
 	system Rasalhague
 		government Pug
-		fleet "Small Southern Merchants" 1500
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Pug" 800
-		fleet "Large Pug" 2000
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Pug" 800
+		add fleet "Large Pug" 2000
 	system Orvala
 		government Pug
-		fleet "Small Southern Merchants" 3000
-		fleet "Large Southern Merchants" 6000
-		fleet "Small Pug" 5000
-		fleet "Large Pug" 9000
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Pug" 5000
+		add fleet "Large Pug" 9000
 	system Altair
 		government Pug
-		fleet "Small Core Merchants" 400
-		fleet "Large Core Merchants" 600
-		fleet "Small Northern Merchants" 1000
-		fleet "Large Northern Merchants" 3000
-		fleet "Small Pug" 700
-		fleet "Large Pug" 900
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Pug" 700
+		add fleet "Large Pug" 900
 	system Vega
 		government "Free Worlds"
 	system "Delta Capricorni"
 		government Pug
-		fleet "Small Core Merchants" 700
-		fleet "Large Core Merchants" 800
-		fleet "Small Pug" 800
-		fleet "Large Pug" 1100
-		fleet "Human Miners" 3000
+		remove fleet "Small Syndicate"
+		remove fleet "Large Syndicate"
+		add fleet "Small Pug" 800
+		add fleet "Large Pug" 1100
 	system Alderamin
 		government Pug
-		fleet "Small Core Merchants" 2000
-		fleet "Large Core Merchants" 3200
-		fleet "Small Pug" 1200
-		fleet "Large Pug" 2500
+		remove fleet "Small Syndicate"
+		remove fleet "Large Syndicate"
+		remove fleet "Small Core Pirates"
+		remove fleet "Large Core Pirates"
+		add fleet "Small Pug" 1200
+		add fleet "Large Pug" 2500
 	system Nocte
 		government Pug
-		fleet "Small Northern Merchants" 1500
-		fleet "Large Northern Merchants" 5000
-		fleet "Small Pug" 3000
-		fleet "Large Pug" 7000
-		fleet "Human Miners" 1600
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Small Northern Pirates"
+		add fleet "Small Pug" 3000
+		add fleet "Large Pug" 7000
 	planet Rand
 		security 0
 	planet Oblivion
@@ -2522,19 +2524,19 @@ event "fwc navy retakes cebalrai"
 	unvisit Menkent
 	system Cebalrai
 		government Republic
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 1500
-		fleet "Small Republic" 500
-		fleet "Large Republic" 600
-		fleet "Large Free Worlds" 5000
+		remove fleet "Small Free Worlds"
+		remove fleet "Large Free Worlds"
+		remove fleet "Large Free Worlds"
+		add fleet "Small Republic" 500
+		add fleet "Large Republic" 681
+		add fleet "Large Free Worlds" 5000
 	system Menkent
 		government Republic
-		fleet "Small Southern Merchants" 700
-		fleet "Large Southern Merchants" 1900
-		fleet "Small Republic" 300
-		fleet "Large Republic" 400
-		fleet "Large Free Worlds" 2000
-		fleet "Human Miners" 2000
+		remove fleet "Small Free Worlds"
+		remove fleet "Large Free Worlds"
+		add fleet "Small Republic" 300
+		add fleet "Large Republic" 500
+		add fleet "Large Free Worlds" 2000
 
 
 
@@ -2576,11 +2578,12 @@ event "fwc peace with the navy"
 		"required reputation" 40
 	system Vega
 		government Pug
-		fleet "Small Northern Merchants" 800
-		fleet "Large Northern Merchants" 3000
-		fleet "Small Pug" 800
-		fleet "Large Pug" 1200
-		fleet "Human Miners" 5000
+		remove fleet "Small Southern Merchants"
+		add fleet "Small Northern Merchants" 800
+		add fleet "Large Northern Merchants" 3000
+		add fleet "Small Pug" 800
+		add fleet "Large Pug" 1200
+		add fleet "Human Miners" 5000
 
 
 
@@ -2599,33 +2602,37 @@ event "fwc battle for rasalhague"
 event "fwc liberation of rasalhague"
 	system Rasalhague
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1500
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Republic" 400
-		fleet "Large Republic" 600
-		fleet "Small Free Worlds" 400
-		fleet "Large Free Worlds" 600
+		add fleet "Small Southern Merchants" 1764
+		add fleet "Large Southern Merchants" 2000
+		add fleet "Small Republic" 400
+		add fleet "Large Republic" 600
+		add fleet "Small Free Worlds" 400
+		add fleet "Large Free Worlds" 600
 	system "Zeta Aquilae"
-		fleet "Small Southern Merchants" 1000
-		fleet "Large Southern Merchants" 3000
+		remove fleet "Small Pug"
+		remove fleet "Large Pug"
 	system Vega
-		fleet "Small Southern Merchants" 1500
-		fleet "Large Southern Merchants" 2000
-		fleet "Human Miners" 5000
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		remove fleet "Small Pug"
+		remove fleet "Large Pug"
+		add fleet "Small Southern Merchants" 1500
+		add fleet "Large Southern Merchants" 2000
 	system Altair
-		fleet "Small Core Merchants" 400
-		fleet "Large Core Merchants" 600
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		remove fleet "Small Pug"
+		remove fleet "Large Pug"
 	system "Delta Capricorni"
-		fleet "Small Core Merchants" 700
-		fleet "Large Core Merchants" 800
-		fleet "Human Miners" 3000
+		remove fleet "Small Pug"
+		remove fleet "Large Pug"
 	system Alderamin
-		fleet "Small Core Merchants" 2000
-		fleet "Large Core Merchants" 3200
+		remove fleet "Small Pug"
+		remove fleet "Large Pug"
 	system Deneb
-		fleet "Small Core Merchants" 10000
-		fleet "Small Pug" 100
-		fleet "Large Pug" 100
+		add fleet "Small Core Merchants" 10000
+		add fleet "Small Pug" 133
+		add fleet "Large Pug" 111
 
 
 
@@ -2638,12 +2645,14 @@ event "fwc reconnect zeta aquilae"
 	link "Zeta Aquilae" Ascella
 	system "Zeta Aquilae"
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 1500
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Republic" 400
-		fleet "Large Republic" 600
-		fleet "Small Free Worlds" 600
-		fleet "Large Free Worlds" 800
+		remove fleet "Small Southern Merchants"
+		remove fleet "Small Southern Merchants"
+		add fleet "Small Southern Merchants" 1500
+		add fleet "Large Southern Merchants" 6000
+		add fleet "Small Republic" 400
+		add fleet "Large Republic" 600
+		add fleet "Small Free Worlds" 600
+		add fleet "Large Free Worlds" 800
 	system Orvala
 		government "Free Worlds"
 
@@ -2659,11 +2668,8 @@ event "fwc reconnect vega"
 	link Sol Vega
 	system Vega
 		government Republic
-		fleet "Small Southern Merchants" 1500
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Republic" 500
-		fleet "Large Republic" 700
-		fleet "Human Miners" 5000
+		add fleet "Small Republic" 500
+		add fleet "Large Republic" 700
 
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -1272,18 +1272,17 @@ fleet "gunboat only"
 
 event "gunboats in Alnasl"
 	system Alnasl
-		fleet "Small Southern Merchants" 1300
-		fleet "Large Southern Merchants" 2500
-		fleet "gunboat only" 800
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "gunboat only" 800
 
 event "normal in Alnasl"
 	system Alnasl
-		fleet "Small Southern Merchants" 1300
-		fleet "Large Southern Merchants" 2500
-		fleet "Small Southern Pirates" 6000
-		fleet "Small Republic" 900
-		fleet "Large Republic" 1100
-		fleet "Navy Surveillance" 1200
+		remove fleet "gunboat only"
+		add fleet "Small Republic" 900
+		add fleet "Large Republic" 1100
+		add fleet "Navy Surveillance" 1200
 
 
 

--- a/data/events.txt
+++ b/data/events.txt
@@ -857,7 +857,7 @@ event "initial deployment 4"
 		remove fleet "Large Southern Merchants"
 		add fleet "Small Southern Merchants" 600
 		add fleet "Large Southern Merchants" 800
-		add leet "Small Free Worlds" 4000
+		add fleet "Small Free Worlds" 4000
 		add fleet "Large Free Worlds" 4800
 		add fleet "Navy Surveillance" 800
 	system Aldhibain
@@ -883,17 +883,24 @@ event "initial deployment 4"
 event "capture of Kornephoros"
 	system Kornephoros
 		government Republic
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 1400
-		fleet "Small Republic" 300
-		fleet "Large Republic" 500
-		fleet "Navy Surveillance" 800
-		fleet "Human Miners" 3000
+		remove fleet "Small Free Worlds"
+		remove fleet "Small Free Worlds"
+		remove fleet "Large Free Worlds"
+		remove fleet "Large Free Worlds"
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		add fleet "Small Southern Merchants" 1200
+		add fleet "Large Southern Merchants" 1400
+		add fleet "Small Republic" 300
+		add fleet "Large Republic" 500
 	system Sabik
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 1000
-		fleet "Small Free Worlds" 400
-		fleet "Large Free Worlds" 600
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Southern Merchants" 800
+		add fleet "Large Southern Merchants" 1000
+		add fleet "Small Free Worlds" 800
+		add fleet "Large Free Worlds" 1200
 	planet Clink
 		description `The mining outpost is swarming with Navy guards; they seem to have turned this moon into a temporary base of operations. The mine has been shut down, and no one is being allowed in or out of the mining outpost. It is not clear whether the miners are prisoners, or merely under a very tight watch.`
 		security 1
@@ -929,13 +936,17 @@ event "temporary ceasefire"
 
 
 
+event "prepare for battle of Kornephoros"
+	system "Kornephoros"
+		fleet "Small Free Worlds" 10000
+
+
+
 event "recapture of Kornephoros"
 	system Aldhibain
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 800
-		fleet "Small Free Worlds" 600
-		fleet "Large Free Worlds" 600
-		fleet "Human Miners" 3000
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Navy Surveillance"
 	system Kornephoros
 		government "Free Worlds"
 		fleet "Small Southern Merchants" 800

--- a/data/events.txt
+++ b/data/events.txt
@@ -1914,25 +1914,28 @@ event "pug invasion 4"
 	unvisit Diphda
 	unvisit Ankaa
 	system Sol
-		fleet "Small Northern Merchants" 300
-		fleet "Large Northern Merchants" 500
-		fleet "Small Republic" 600
-		fleet "Large Republic" 900
-		fleet "Small Core Merchants" 1000
-		fleet "Large Core Merchants" 2000
+		remove fleet "Small Core Merchants"
+		remove fleet "Small Core Merchants"
+		remove fleet "Large Core Merchants"
+		remove fleet "Large Core Merchants"
+		remove fleet "Small Syndicate"
+		remove fleet "Large Syndicate"
+		add fleet "Small Northern Merchants" 750
+		add fleet "Large Northern Merchants" 1750
+		add fleet "Small Republic" 2400
+		add fleet "Large Republic" 3600
+		add fleet "Small Core Merchants" 1000
+		add fleet "Large Core Merchants" 2000
 	system Diphda
 		government Pug
-		fleet "Small Core Merchants" 2000
-		fleet "Large Core Merchants" 600
-		fleet "Small Pug" 1000
-		fleet "Large Pug" 1500
+		remove fleet "Small Syndicate"
+		add fleet "Small Pug" 1000
+		add fleet "Large Pug" 1500
 	system Caph
 		government Pug
-		fleet "Small Core Merchants" 500
-		fleet "Large Core Merchants" 600
-		fleet "Small Pug" 700
-		fleet "Large Pug" 1000
-		fleet "Human Miners" 2000
+		remove fleet "Small Syndicate"
+		add fleet "Small Pug" 700
+		add fleet "Large Pug" 1000
 	planet Reunion
 		security 0
 	planet "Kraken Station"

--- a/data/events.txt
+++ b/data/events.txt
@@ -34,11 +34,13 @@ event "war begins"
 	date 4 7 3014
 	system "Gamma Corvi"
 		government "Free Worlds"
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 1400
-		fleet "Small Free Worlds" 600
-		fleet "Large Free Worlds" 1300
-		fleet "Human Miners" 4000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		add fleet "Small Free Worlds" 600
+		add fleet "Large Free Worlds" 1300
+		add fleet "Small Southern Merchants" 600
+		add fleet "Large Southern Merchants" 1400
+		add fleet "Human Miners" 10000
 	system Spica
 		government "Free Worlds"
 	system Minkar
@@ -94,31 +96,40 @@ event "war begins"
 	system "Kappa Centauri"
 		government "Free Worlds"
 	system Castor
-		fleet "Small Northern Merchants" 800
-		fleet "Large Northern Merchants" 1100
-		fleet "Small Republic" 800
-		fleet "Large Republic" 400
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		add fleet "Small Northern Merchants" 800
+		add fleet "Large Northern Merchants" 1100
+		add fleet "Small Republic" 4000
+		add fleet "Large Republic" 2000
 	system Pollux
-		fleet "Small Northern Merchants" 700
-		fleet "Large Northern Merchants" 1100
-		fleet "Small Republic" 700
-		fleet "Large Republic" 900
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		add fleet "Small Northern Merchants" 700
+		add fleet "Large Northern Merchants" 1100
+		add fleet "Small Republic" 2333
+		add fleet "Large Republic" 1636
 	system Vega
-		fleet "Small Northern Merchants" 1000
-		fleet "Large Northern Merchants" 4000
-		fleet "Small Republic" 900
-		fleet "Large Republic" 1000
-		fleet "Human Miners" 6250
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		add fleet "Small Northern Merchants" 1000
+		add fleet "Large Northern Merchants" 4000
+		add fleet "Small Republic" 2057
+		add fleet "Large Republic" 1250
 	system Denebola
-		fleet "Small Northern Merchants" 1000
-		fleet "Large Northern Merchants" 3000
-		fleet "Small Republic" 700
-		fleet "Large Republic" 900
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		add fleet "Small Northern Merchants" 1000
+		add fleet "Large Northern Merchants" 3000
+		add fleet "Small Republic" 2333
+		add fleet "Large Republic" 1636
 	system Merak
-		fleet "Small Northern Merchants" 1500
-		fleet "Large Northern Merchants" 4000
-		fleet "Small Republic" 1100
-		fleet "Large Republic" 1300
+		remove fleet "Small Northern Merchants"
+		remove fleet "Large Northern Merchants"
+		add fleet "Small Northern Merchants" 1500
+		add fleet "Large Northern Merchants" 4000
+		add fleet "Small Republic" 2444
+		add fleet "Large Republic" 1925
 	planet Geminus
 		description `Until recently, Geminus was home to the Republic Navy Yard, the largest shipyard in human space. Now, there is nothing left of the shipyard but a gaping crater in the ground, from the recent terrorist bombing.`
 		spaceport `Fortunately, the spaceport and residential areas survived the bombing, which was focused only on the Navy yard and happened early in the morning, when very few people were at work.`
@@ -1935,40 +1946,13 @@ event "pug flee"
 		fleet "Large Southern Pirates" 3000
 	system Deneb
 		fleet "Small Core Merchants" 5000
-		object
-			sprite star/g5
-			period 10
-		object Pugglemug
-			sprite planet/ocean2
-			distance 317.56
-			period 90.543791
-			object
-				sprite planet/dust3
-				distance 159
-				period 16.370052
-		object Pugglequat
-			sprite planet/desert3
-			distance 966.8
-			period 480.9777
-			object
-				sprite planet/rhea
-				distance 156
-				period 18.632773
-		object
-			sprite planet/dust7
-			distance 1538.84
-			period 965.85111
-		object
-			sprite planet/dust0
-			distance 1788.4
-			period 1210.0881
-		object "Pug Wormhole"
+		add object "Pug Wormhole"
 			sprite planet/wormhole
 			distance 2320.29
 			period 1788.2712
 
 
-
+# Reconciliation branch resolution
 event "pug territory liberated"
 	system Orvala
 		government "Free Worlds"
@@ -2554,6 +2538,7 @@ event "fwc reconnect vega"
 
 
 
+# Checkmate branch resolution
 event "fwc pug defeated"
 	system Altair
 		government Republic

--- a/data/events.txt
+++ b/data/events.txt
@@ -39,8 +39,8 @@ event "war begins"
 		remove fleet "Small Southern Pirates"
 		add fleet "Small Free Worlds" 600
 		add fleet "Large Free Worlds" 1300
-		"set period" fleet "Small Southern Merchants" 600
-		"set period" fleet "Large Southern Merchants" 1400
+		set fleet "Small Southern Merchants" 600
+		set fleet "Large Southern Merchants" 1400
 	system Spica
 		government "Free Worlds"
 	system Minkar
@@ -96,30 +96,30 @@ event "war begins"
 	system "Kappa Centauri"
 		government "Free Worlds"
 	system Castor
-		"set period" fleet "Small Northern Merchants" 800
-		"set period" fleet "Large Northern Merchants" 1100
-		"set period" fleet "Small Republic" 800
-		"set period" fleet "Large Republic" 400
+		set fleet "Small Northern Merchants" 800
+		set fleet "Large Northern Merchants" 1100
+		set fleet "Small Republic" 800
+		set fleet "Large Republic" 400
 	system Pollux
-		"set period fleet "Small Northern Merchants" 700
-		"set period" fleet "Large Northern Merchants" 1100
-		"set period" fleet "Small Republic" 700
-		"set period" fleet "Large Republic" 900
+		set fleet "Small Northern Merchants" 700
+		set fleet "Large Northern Merchants" 1100
+		set fleet "Small Republic" 700
+		set fleet "Large Republic" 900
 	system Vega
-		"set period" fleet "Small Northern Merchants" 1000
-		"set period" fleet "Large Northern Merchants" 4000
-		"set period" fleet "Small Republic" 900
-		"set period" fleet "Large Republic" 1000
+		set fleet "Small Northern Merchants" 1000
+		set fleet "Large Northern Merchants" 4000
+		set fleet "Small Republic" 900
+		set fleet "Large Republic" 1000
 	system Denebola
-		"set period" fleet "Small Northern Merchants" 1000
-		"set period" fleet "Large Northern Merchants" 3000
-		"set period" fleet "Small Republic" 700
-		"set period" fleet "Large Republic" 900
+		set fleet "Small Northern Merchants" 1000
+		set fleet "Large Northern Merchants" 3000
+		set fleet "Small Republic" 700
+		set fleet "Large Republic" 900
 	system Merak
-		"set period" fleet "Small Northern Merchants" 1500
-		"set period" fleet "Large Northern Merchants" 4000
-		"set period" fleet "Small Republic" 1100
-		"set period" fleet "Large Republic" 1300
+		set fleet "Small Northern Merchants" 1500
+		set fleet "Large Northern Merchants" 4000
+		set fleet "Small Republic" 1100
+		set fleet "Large Republic" 1300
 	planet Geminus
 		description `Until recently, Geminus was home to the Republic Navy Yard, the largest shipyard in human space. Now, there is nothing left of the shipyard but a gaping crater in the ground, from the recent terrorist bombing.`
 		spaceport `Fortunately, the spaceport and residential areas survived the bombing, which was focused only on the Navy yard and happened early in the morning, when very few people were at work.`
@@ -156,31 +156,31 @@ event "initial deployment 1"
 		remove fleet "Large Militia"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		"set period" fleet "Small Southern Merchants" 1200
-		"set period" fleet "Large Southern Merchants" 1700
+		set fleet "Small Southern Merchants" 1200
+		set fleet "Large Southern Merchants" 1700
 		add fleet "Small Free Worlds" 800
 		add fleet "Large Free Worlds" 1500
 	system Minkar
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
 		remove fleet "Large Southern Pirates"
-		"set period" fleet "Small Southern Merchants" 700
-		"set period" fleet "Large Southern Merchants" 1500
+		set fleet "Small Southern Merchants" 700
+		set fleet "Large Southern Merchants" 1500
 		add fleet "Small Free Worlds" 700
 		add fleet "Large Free Worlds" 1200
 	system Mimosa
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
 		remove fleet "Large Southern Pirates"
-		"set period" fleet "Small Southern Merchants" 1200
-		"set period" fleet "Large Southern Merchants" 2300
+		set fleet "Small Southern Merchants" 1200
+		set fleet "Large Southern Merchants" 2300
 		add fleet "Small Free Worlds" 1200
 		add fleet "Large Free Worlds" 1900
 	system Kraz
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 900
-		"set period" fleet "Large Southern Merchants" 1600
+		set fleet "Small Southern Merchants" 900
+		set fleet "Large Southern Merchants" 1600
 		add fleet "Small Free Worlds" 700
 		add fleet "Large Free Worlds" 900
 	system Acrux
@@ -188,82 +188,82 @@ event "initial deployment 1"
 		remove fleet "Large Militia"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		"set period" fleet "Small Southern Merchants" 500
-		"set period" fleet "Large Southern Merchants" 800
+		set fleet "Small Southern Merchants" 500
+		set fleet "Large Southern Merchants" 800
 		add fleet "Small Free Worlds" 700
 		add fleet "Large Free Worlds" 1100
 	
 	system "Tania Australis"
 		remove fleet "Small Northern Pirates"
 		remove fleet "Large Northern Pirates"
-		"set period" fleet "Small Northern Merchants" 1400
-		"set period" fleet "Large Northern Merchants" 2900
-		"set period" fleet "Small Republic" 600
+		set fleet "Small Northern Merchants" 1400
+		set fleet "Large Northern Merchants" 2900
+		set fleet "Small Republic" 600
 		add fleet "Large Republic" 400
 		add fleet "Navy Surveillance" 2000
 	planet Ingot
 		add description `Ingot is also now home to a burgeoning Navy base, although since the planet is so unlivable most of the troops are just living in ships in orbit.`
 	system Fala
-		"set period" fleet "Small Northern Merchants" 1900
-		"set period" fleet "Large Northern Merchants" 3500
-		"set period" fleet "Small Republic" 600
+		set fleet "Small Northern Merchants" 1900
+		set fleet "Large Northern Merchants" 3500
+		set fleet "Small Republic" 600
 		add fleet "Large Republic" 400
-		"set period" fleet "Small Northern Pirates" 4000
-		"set period" fleet "Large Northern Pirates" 8000
+		set fleet "Small Northern Pirates" 4000
+		set fleet "Large Northern Pirates" 8000
 		add fleet "Navy Surveillance" 2000
-		"set period" fleet "Human Miners" 3000
+		set fleet "Human Miners" 3000
 	system Phecda
 		remove fleet "Large Northern Merchants"
 		remove fleet "Large Southern Merchants"
-		"set period" fleet "Small Northern Merchants" 900
-		"set period" fleet "Small Southern Merchants" 1100
-		"set period" fleet "Small Republic" 900
+		set fleet "Small Northern Merchants" 900
+		set fleet "Small Southern Merchants" 1100
+		set fleet "Small Republic" 900
 		add fleet "Large Republic" 1100
 		add fleet "Navy Surveillance" 2000
-		"set period" fleet "Human Miners" 3000
+		set fleet "Human Miners" 3000
 	system Algorel
 		remove fleet "Small Militia"
-		"set period" fleet "Small Southern Merchants" 800
-		"set period" fleet "Large Southern Merchants" 1200
-		"set period" fleet "Small Republic" 700
+		set fleet "Small Southern Merchants" 800
+		set fleet "Large Southern Merchants" 1200
+		set fleet "Small Republic" 700
 		add fleet "Large Republic" 500
-		"set period" fleet "Small Southern Pirates" 2500
-		"set period" fleet "Large Southern Pirates" 8000
+		set fleet "Small Southern Pirates" 2500
+		set fleet "Large Southern Pirates" 8000
 		add fleet "Navy Surveillance" 2000
 	planet "New Wales"
 		add description `The Republic Navy has planted a base on New Wales: so far, just a densely packed cluster of prefabricated barracks and infirmary buildings on the outskirts of one of the mining colonies.`
 	system Porrima
-		"set period" fleet "Small Southern Merchants" 1400
-		"set period" fleet "Large Southern Merchants" 4000
-		"set period" fleet "Small Republic" 1200
+		set fleet "Small Southern Merchants" 1400
+		set fleet "Large Southern Merchants" 4000
+		set fleet "Small Republic" 1200
 		add fleet "Large Republic" 1800
-		"set period" fleet "Small Southern Pirates" 9000
+		set fleet "Small Southern Pirates" 9000
 		add fleet "Navy Surveillance" 2000
 	system Ipsing
-		"set period" fleet "Small Southern Merchants" 2800
-		"set period" fleet "Large Southern Merchants" 7000
+		set fleet "Small Southern Merchants" 2800
+		set fleet "Large Southern Merchants" 7000
 		add fleet "Small Republic" 2500
 		add fleet "Large Republic" 4000
-		"set period" fleet "Small Southern Pirates" 5000
+		set fleet "Small Southern Pirates" 5000
 		add fleet "Navy Surveillance" 2000
 	system Mizar
-		"set period" fleet "Small Southern Merchants" 1400
-		"set period" fleet "Large Southern Merchants" 4500
+		set fleet "Small Southern Merchants" 1400
+		set fleet "Large Southern Merchants" 4500
 		add fleet "Small Republic" 1000
 		add fleet "Large Republic" 1400
-		"set period" fleet "Small Southern Pirates" 9000
+		set fleet "Small Southern Pirates" 9000
 		add fleet "Navy Surveillance" 2000
 	system Muphrid
-		"set period" fleet "Small Southern Merchants" 1200
-		"set period" fleet "Large Southern Merchants" 4800
-		"set period" fleet "Small Republic" 1100
+		set fleet "Small Southern Merchants" 1200
+		set fleet "Large Southern Merchants" 4800
+		set fleet "Small Republic" 1100
 		add fleet "Large Republic" 1900
-		"set period" fleet "Small Southern Pirates" 9000
+		set fleet "Small Southern Pirates" 9000
 		add fleet "Navy Surveillance" 2000
 	system Menkent
-		"set period" fleet "Small Southern Merchants" 700
-		"set period" fleet "Large Southern Merchants" 1900
-		"set period" fleet "Small Republic" 500
+		set fleet "Small Southern Merchants" 700
+		set fleet "Large Southern Merchants" 1900
+		set fleet "Small Republic" 500
 		add fleet "Large Republic" 600
 		add fleet "Navy Surveillance" 2000
 	planet "New Austria"
@@ -280,69 +280,69 @@ event "initial deployment 2"
 	system Izar
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 500
-		"set period" fleet "Large Southern Merchants" 1500
+		set fleet "Small Southern Merchants" 500
+		set fleet "Large Southern Merchants" 1500
 		add fleet "Small Free Worlds" 700
 		add fleet "Large Free Worlds" 1000
 	system "Zeta Centauri"
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 700
-		"set period" fleet "Large Southern Merchants" 1700
+		set fleet "Small Southern Merchants" 700
+		set fleet "Large Southern Merchants" 1700
 		add fleet "Small Free Worlds" 1200
 		add fleet "Large Free Worlds" 2000
-		"set period" fleet "Small Southern Pirates" 6000
-		"set period" fleet "Large Southern Pirates" 9000
+		set fleet "Small Southern Pirates" 6000
+		set fleet "Large Southern Pirates" 9000
 	system Hadar
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		"set period" fleet "Large Southern Merchants" 600
+		set fleet "Large Southern Merchants" 600
 		add fleet "Small Free Worlds" 600
 		add fleet "Large Free Worlds" 1100
 	system Alkaid
-		"set period" fleet "Small Southern Merchants" 1200
-		"set period" fleet "Large Southern Merchants" 4000
+		set fleet "Small Southern Merchants" 1200
+		set fleet "Large Southern Merchants" 4000
 		add fleet "Small Free Worlds" 6000
 		add fleet "Large Free Worlds" 10000
-		"set period" fleet "Small Southern Pirates" 4000
-		"set period" fleet "Large Southern Pirates" 8000
+		set fleet "Small Southern Pirates" 4000
+		set fleet "Large Southern Pirates" 8000
 	system Zubeneschamali
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Large Southern Merchants" 1000
+		set fleet "Large Southern Merchants" 1000
 		add fleet "Small Free Worlds" 1400
 		add fleet "Large Free Worlds" 2400
-		"set period" fleet "Small Southern Pirates" 4000
-		"set period" fleet "Large Southern Pirates" 5000
+		set fleet "Small Southern Pirates" 4000
+		set fleet "Large Southern Pirates" 5000
 	system Kochab
 		remove fleet "Small Militia"
-		"set period" fleet "Small Southern Merchants" 1800
-		"set period" fleet "Large Southern Merchants" 5000
+		set fleet "Small Southern Merchants" 1800
+		set fleet "Large Southern Merchants" 5000
 		add fleet "Small Free Worlds" 5000
-		"set period" fleet "Small Southern Pirates" 6000
+		set fleet "Small Southern Pirates" 6000
 	system Ildaria
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 900
-		"set period" fleet "Large Southern Merchants" 1800
+		set fleet "Small Southern Merchants" 900
+		set fleet "Large Southern Merchants" 1800
 		add fleet "Small Free Worlds" 2200
 		add fleet "Large Free Worlds" 3600
-		"set period" fleet "Small Southern Pirates" 4000
-		"set period" fleet "Large Southern Pirates" 7000
+		set fleet "Small Southern Pirates" 4000
+		set fleet "Large Southern Pirates" 7000
 	
 	system Mora
-		"set period" fleet "Small Southern Merchants" 2800
-		"set period" fleet "Large Southern Merchants" 5000
-		"set period" fleet "Small Southern Pirates" 3000
-		"set period" fleet "Large Southern Pirates" 4000
-		"set period" fleet "Small Republic" 1000
+		set fleet "Small Southern Merchants" 2800
+		set fleet "Large Southern Merchants" 5000
+		set fleet "Small Southern Pirates" 3000
+		set fleet "Large Southern Pirates" 4000
+		set fleet "Small Republic" 1000
 		add fleet "Large Republic" 2000
 		add fleet "Navy Surveillance" 1600
-		"set period" fleet "Human Miners" 4000
+		set fleet "Human Miners" 4000
 	system "Delta Velorum"
-		"set period" fleet "Small Republic" 1600
+		set fleet "Small Republic" 1600
 		add fleet "Large Republic" 2400
 		add fleet "Navy Surveillance" 1600
 	system Turais
@@ -350,13 +350,13 @@ event "initial deployment 2"
 		add fleet "Large Republic" 1800
 		add fleet "Navy Surveillance" 1600
 	system Gacrux
-		"set period" fleet "Small Southern Pirates" 2000
-		"set period" fleet "Large Southern Pirates" 4000
-		"set period" fleet "Small Republic" 2000
+		set fleet "Small Southern Pirates" 2000
+		set fleet "Large Southern Pirates" 4000
+		set fleet "Small Republic" 2000
 		add fleet "Large Republic" 3000
 		add fleet "Navy Surveillance" 1600
 	system "Cor Caroli"
-		"set period" fleet "Small Republic" 1200
+		set fleet "Small Republic" 1200
 		add fleet "Large Republic" 1800
 		add fleet "Navy Surveillance" 1600
 	system Muhlifain
@@ -418,90 +418,90 @@ event "initial deployment 3"
 	system Zubenelgenubi
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Large Southern Merchants" 900
+		set fleet "Large Southern Merchants" 900
 		add fleet "Small Free Worlds" 800
 		add fleet "Large Free Worlds" 1000
-		"set period" fleet "Small Southern Pirates" 5000
-		"set period" fleet "Large Southern Pirates" 8000
+		set fleet "Small Southern Pirates" 5000
+		set fleet "Large Southern Pirates" 8000
 	system Unukalhai
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 900
-		"set period" fleet "Large Southern Merchants" 3000
+		set fleet "Small Southern Merchants" 900
+		set fleet "Large Southern Merchants" 3000
 		add fleet "Small Free Worlds" 3000
 		add fleet "Large Free Worlds" 6000
 	system Sabik
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Large Southern Merchants" 600
+		set fleet "Large Southern Merchants" 600
 		add fleet "Small Free Worlds" 1000
 		add fleet "Large Free Worlds" 1600
 	system Aldhibain
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Large Southern Merchants" 500
+		set fleet "Large Southern Merchants" 500
 		add fleet "Small Free Worlds" 600
 		add fleet "Large Free Worlds" 700
-		"set period" fleet "Small Southern Pirates" 1400
-		"set period" fleet "Large Southern Pirates" 3000
+		set fleet "Small Southern Pirates" 1400
+		set fleet "Large Southern Pirates" 3000
 	system Kornephoros
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Large Southern Merchants" 700
-		"set period" fleet "Small Southern Pirates" 5000
+		set fleet "Large Southern Merchants" 700
+		set fleet "Small Southern Pirates" 5000
 		add fleet "Small Free Worlds" 1000
 		add fleet "Large Free Worlds" 2000
 	
 	system Wei
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 800
-		"set period" fleet "Large Southern Merchants" 2500
-		"set period" fleet "Small Southern Pirates" 6000
+		set fleet "Small Southern Merchants" 800
+		set fleet "Large Southern Merchants" 2500
+		set fleet "Small Southern Pirates" 6000
 		add fleet "Small Republic" 800
 		add fleet "Large Republic" 700
 		add fleet "Navy Surveillance" 1200
 	system Seginus
 		remove fleet "Small Militia"
-		"set period" fleet "Small Southern Merchants" 1200
-		"set period" fleet "Large Southern Merchants" 2700
-		"set period" fleet "Small Southern Pirates" 8000
+		set fleet "Small Southern Merchants" 1200
+		set fleet "Large Southern Merchants" 2700
+		set fleet "Small Southern Pirates" 8000
 		add fleet "Small Republic" 1200
 		add fleet "Large Republic" 1400
 		add fleet "Navy Surveillance" 1200
 	system Alnasl
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 1300
-		"set period" fleet "Large Southern Merchants" 2500
-		"set period" fleet "Small Southern Pirates" 6000
+		set fleet "Small Southern Merchants" 1300
+		set fleet "Large Southern Merchants" 2500
+		set fleet "Small Southern Pirates" 6000
 		add fleet "Small Republic" 900
 		add fleet "Large Republic" 1100
 		add fleet "Navy Surveillance" 1200
 	system Eber
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 1900
-		"set period" fleet "Large Southern Merchants" 2900
-		"set period" fleet "Small Southern Pirates" 3000
+		set fleet "Small Southern Merchants" 1900
+		set fleet "Large Southern Merchants" 2900
+		set fleet "Small Southern Pirates" 3000
 		add fleet "Small Republic" 1000
 		add fleet "Large Republic" 1500
 		add fleet "Navy Surveillance" 1200
 	system "Alpha Arae"
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 2100
-		"set period" fleet "Large Southern Merchants" 8000
-		"set period" fleet "Small Southern Pirates" 6000
-		"set period" fleet "Large Southern Pirates" 13000
+		set fleet "Small Southern Merchants" 2100
+		set fleet "Large Southern Merchants" 8000
+		set fleet "Small Southern Pirates" 6000
+		set fleet "Large Southern Pirates" 13000
 		add fleet "Small Republic" 900
 		add fleet "Large Republic" 800
 		add fleet "Navy Surveillance" 1200
 	system "Kaus Borealis"
 		remove fleet "Small Militia"
-		"set period" fleet "Small Southern Merchants" 900
-		"set period" fleet "Large Southern Merchants" 4000
-		"set period" fleet "Small Southern Pirates" 8000
+		set fleet "Small Southern Merchants" 900
+		set fleet "Large Southern Merchants" 4000
+		set fleet "Small Southern Pirates" 8000
 		add fleet "Small Republic" 1100
 		add fleet "Large Republic" 800
 		add fleet "Navy Surveillance" 1200
@@ -670,112 +670,112 @@ event "initial deployment 4"
 	system Sargas
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 600
-		"set period" fleet "Large Southern Merchants" 2500
-		"set period" fleet "Small Southern Pirates" 3000
-		"set period" fleet "Large Southern Pirates" 5000
+		set fleet "Small Southern Merchants" 600
+		set fleet "Large Southern Merchants" 2500
+		set fleet "Small Southern Pirates" 3000
+		set fleet "Large Southern Pirates" 5000
 		add fleet "Small Free Worlds" 1000
 		add fleet "Large Free Worlds" 1500
 		add fleet "Navy Surveillance" 800
 	system Dschubba
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 800
-		"set period" fleet "Large Southern Merchants" 2600
-		"set period" fleet "Small Southern Pirates" 3000
-		"set period" fleet "Large Southern Pirates" 6000
+		set fleet "Small Southern Merchants" 800
+		set fleet "Large Southern Merchants" 2600
+		set fleet "Small Southern Pirates" 3000
+		set fleet "Large Southern Pirates" 6000
 		add fleet "Small Free Worlds" 2000
 		add fleet "Large Free Worlds" 3000
 		add fleet "Navy Surveillance" 800
 	system Lesath
 		remove fleet "Small Militia"
-		"set period" fleet "Small Southern Merchants" 800
-		"set period" fleet "Large Southern Merchants" 1600
-		"set period" fleet "Small Southern Pirates" 3000
-		"set period" fleet "Large Southern Pirates" 7000
+		set fleet "Small Southern Merchants" 800
+		set fleet "Large Southern Merchants" 1600
+		set fleet "Small Southern Pirates" 3000
+		set fleet "Large Southern Pirates" 7000
 		add fleet "Small Free Worlds" 800
 		add fleet "Large Free Worlds" 1100
 		add fleet "Navy Surveillance" 800
 	system Atria
 		remove fleet "Small Militia"
-		"set period" fleet "Small Southern Merchants" 700
-		"set period" fleet "Large Southern Merchants" 2600
-		"set period" fleet "Small Southern Pirates" 5000
-		"set period" fleet "Large Southern Pirates" 8000
+		set fleet "Small Southern Merchants" 700
+		set fleet "Large Southern Merchants" 2600
+		set fleet "Small Southern Pirates" 5000
+		set fleet "Large Southern Pirates" 8000
 		add fleet "Small Free Worlds" 1000
 		add fleet "Large Free Worlds" 2100
 	system Alniyat
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Large Southern Merchants" 600
+		set fleet "Large Southern Merchants" 600
 		add fleet "Small Free Worlds" 1500
 		add fleet "Large Free Worlds" 4000
 	system Han
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 800
-		"set period" fleet "Large Southern Merchants" 4000
-		"set period" fleet "Small Southern Pirates" 2000
-		"set period" fleet "Large Southern Pirates" 9000
+		set fleet "Small Southern Merchants" 800
+		set fleet "Large Southern Merchants" 4000
+		set fleet "Small Southern Pirates" 2000
+		set fleet "Large Southern Pirates" 9000
 		add fleet "Small Free Worlds" 3000
 		add fleet "Large Free Worlds" 8000
 	system Pherkad
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Large Southern Merchants" 700
+		set fleet "Large Southern Merchants" 700
 		add fleet "Small Free Worlds" 900
 		add fleet "Large Free Worlds" 1700
-		"set period" fleet "Small Southern Pirates" 1000
-		"set period" fleet "Large Southern Pirates" 1900
+		set fleet "Small Southern Pirates" 1000
+		set fleet "Large Southern Pirates" 1900
 	system "Beta Lupi"
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Small Southern Merchants" 800
-		"set period" fleet "Small Southern Pirates" 1100
-		"set period" fleet "Large Southern Pirates" 1600
+		set fleet "Small Southern Merchants" 800
+		set fleet "Small Southern Pirates" 1100
+		set fleet "Large Southern Pirates" 1600
 		add fleet "Small Free Worlds" 4000
 		add fleet "Large Free Worlds" 8000
 	system "Yed Prior"
 		remove fleet "Small Militia"
 		remove fleet "Large Militia"
-		"set period" fleet "Large Southern Merchants" 1100
-		"set period" fleet "Small Southern Pirates" 1000
-		"set period" fleet "Large Southern Pirates" 2000
+		set fleet "Large Southern Merchants" 1100
+		set fleet "Small Southern Pirates" 1000
+		set fleet "Large Southern Pirates" 2000
 		add fleet "Small Free Worlds" 5000
 		add fleet "Large Free Worlds" 8000
 	system "Kappa Centauri"
 		remove fleet "Small Militia"
-		"set period" fleet "Small Southern Merchants" 900
-		"set period" fleet "Large Southern Merchants" 2700
-		"set period" fleet "Small Southern Pirates" 1600
+		set fleet "Small Southern Merchants" 900
+		set fleet "Large Southern Merchants" 2700
+		set fleet "Small Southern Pirates" 1600
 		add fleet "Large Southern Pirates" 2000
 		add fleet "Small Free Worlds" 3000
 		add fleet "Large Free Worlds" 5000
 	
 	system Rastaban
-		"set period" fleet "Small Southern Merchants" 1000
-		"set period" fleet "Large Southern Merchants" 1900
-		"set period" fleet "Small Southern Pirates" 4000
-		"set period" fleet "Large Southern Pirates" 8000
+		set fleet "Small Southern Merchants" 1000
+		set fleet "Large Southern Merchants" 1900
+		set fleet "Small Southern Pirates" 4000
+		set fleet "Large Southern Pirates" 8000
 		add fleet "Small Republic" 900
 		add fleet "Large Republic" 700
 		add fleet "Navy Surveillance" 1200
 	system Sabik
-		"set period" fleet "Small Southern Merchants" 600
-		"set period" fleet "Large Southern Merchants" 800
-		"set period" fleet "Small Free Worlds" 800
-		"set period" fleet "Large Free Worlds" 1200
+		set fleet "Small Southern Merchants" 600
+		set fleet "Large Southern Merchants" 800
+		set fleet "Small Free Worlds" 800
+		set fleet "Large Free Worlds" 1200
 		add fleet "Navy Surveillance" 800
 	system Aldhibain
-		"set period" fleet "Small Southern Merchants" 600
-		"set period" fleet "Large Southern Merchants" 800
-		"set period" fleet "Large Free Worlds" 600
+		set fleet "Small Southern Merchants" 600
+		set fleet "Large Southern Merchants" 800
+		set fleet "Large Free Worlds" 600
 		add fleet "Navy Surveillance" 800
 	system Kornephoros
-		"set period" fleet "Small Southern Merchants" 800
-		"set period" fleet "Large Southern Merchants" 1000
-		"set period" fleet "Small Free Worlds" 900
-		"set period" fleet "Large Free Worlds" 1700
+		set fleet "Small Southern Merchants" 800
+		set fleet "Large Southern Merchants" 1000
+		set fleet "Small Free Worlds" 900
+		set fleet "Large Free Worlds" 1700
 		add fleet "Navy Surveillance" 800
 
 
@@ -785,16 +785,16 @@ event "capture of Kornephoros"
 		government Republic
 		remove fleet "Small Free Worlds"
 		remove fleet "Large Free Worlds"
-		"set period" fleet "Small Southern Merchants" 1200
-		"set period" fleet "Large Southern Merchants" 1400
+		set fleet "Small Southern Merchants" 1200
+		set fleet "Large Southern Merchants" 1400
 		add fleet "Small Republic" 300
 		add fleet "Large Republic" 500
 	system Sabik
 		remove fleet "Navy Surveillance"
-		"set period" fleet "Small Southern Merchants" 800
-		"set period" fleet "Large Southern Merchants" 1000
-		"set period" fleet "Small Free Worlds" 400
-		"set period" fleet "Large Free Worlds" 600
+		set fleet "Small Southern Merchants" 800
+		set fleet "Large Southern Merchants" 1000
+		set fleet "Small Free Worlds" 400
+		set fleet "Large Free Worlds" 600
 	planet Clink
 		description `The mining outpost is swarming with Navy guards; they seem to have turned this moon into a temporary base of operations. The mine has been shut down, and no one is being allowed in or out of the mining outpost. It is not clear whether the miners are prisoners, or merely under a very tight watch.`
 		security 1
@@ -850,9 +850,9 @@ event "recapture of Kornephoros"
 		government "Free Worlds"
 		add fleet "Small Southern Merchants" 800
 		add fleet "Large Southern Merchants" 1000
-		"set period" "Small Free Worlds" 900
+		set fleet "Small Free Worlds" 900
 		add fleet "Large Free Worlds" 1700
-		"set period" fleet "Human Miners" 3000
+		set fleet "Human Miners" 3000
 	planet Clink
 		description `About a decade ago, a mining corporation from Zug planted a colony on Clink for harvesting some rare earth minerals that are present in this moon's crust due to its unusually high rate of asteroid impacts. The atmosphere here is too thin to breathe without a respirator, and because of the low gravity, the dust raised by the mining operations hangs perpetually in the air.`
 		description `The miners who work here are a tight-knit group, since most of them were part of the original colonization team. They are not particularly open to outsiders, and the facilities here are so rudimentary that they do not even stock fuel for visiting ships.`
@@ -946,12 +946,12 @@ event "plasma turret available"
 
 event "fw conservatory founded"
 	system "Yed Prior"
-		"set period" fleet "Small Southern Merchants" 500
-		"set period" fleet "Large Southern Merchants" 800
-		"set period" fleet "Small Southern Pirates" 1200
-		"set period" fleet "Large Southern Pirates" 2400
-		"set period" fleet "Small Free Worlds" 1000
-		"set period" fleet "Large Free Worlds" 1500
+		set fleet "Small Southern Merchants" 500
+		set fleet "Large Southern Merchants" 800
+		set fleet "Small Southern Pirates" 1200
+		set fleet "Large Southern Pirates" 2400
+		set fleet "Small Free Worlds" 1000
+		set fleet "Large Free Worlds" 1500
 	planet Winter
 		add attributes research
 		add description `	Winter is home to the Free Worlds Conservatory, a new university that is focused on making terraforming technology and expertise available at a reasonable price, as well as on ecological protection and renewal.`
@@ -964,7 +964,7 @@ event "battle for Thule"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Small Northern Pirates"
 		remove fleet "Large Northern Pirates"
-		"set period" fleet "Small Southern Pirates" 10000
+		set fleet "Small Southern Pirates" 10000
 
 
 
@@ -975,8 +975,8 @@ event "Thule becomes independent"
 		add fleet "Large Independent" 600
 		add fleet "Small Southern Merchants" 2000
 		add fleet "Large Southern Merchants" 4000
-		"set period" fleet "Small Southern Pirates" 2500
-		"set period" fleet "Large Southern Pirates" 5000
+		set fleet "Small Southern Pirates" 2500
+		set fleet "Large Southern Pirates" 5000
 		add fleet "Large Free Worlds" 1500
 	planet Thule
 		description `Thule is a mountainous world with a population of nearly a billion, settled in the early days of space exploration. When the colony was first established, the Earth government did not yet have the strength to control any system but its own, and when the Republic was formed, Thule did not join, and has repulsed all efforts to force them to do so.`
@@ -994,8 +994,8 @@ event "fw suppressed Bloodsea"
 		remove fleet "Large Militia"
 		add fleet "Small Free Worlds" 800
 		add fleet "Large Free Worlds" 1600
-		"set period" fleet "Small Southern Pirates" 4000
-		"set period" fleet "Large Southern Pirates" 8000
+		set fleet "Small Southern Pirates" 4000
+		set fleet "Large Southern Pirates" 8000
 
 
 
@@ -1003,9 +1003,9 @@ event "fw abandoned Bloodsea"
 	system Antares
 		government Pirate
 		remove fleet "Small Free Worlds"
-		"set period" fleet "Small Southern Pirates" 1000
-		"set period" fleet "Large Southern Pirates" 2000
-		"set period" fleet "Large Free Worlds" 5000
+		set fleet "Small Southern Pirates" 1000
+		set fleet "Large Southern Pirates" 2000
+		set fleet "Large Free Worlds" 5000
 
 
 
@@ -1019,8 +1019,8 @@ event "fw suppressed Greenrock"
 		remove fleet "Large Militia"
 		add fleet "Small Free Worlds" 500
 		add fleet "Large Free Worlds" 800
-		"set period" fleet "Small Southern Pirates" 3000
-		"set period" fleet "Large Southern Pirates" 5000
+		set fleet "Small Southern Pirates" 3000
+		set fleet "Large Southern Pirates" 5000
 
 
 
@@ -1028,13 +1028,13 @@ event "fw abandoned Greenrock"
 	system Shaula
 		government Pirate
 		remove fleet "Small Free Worlds"
-		"set period" fleet "Small Southern Pirates" 500
-		"set period" fleet "Large Southern Pirates" 800
+		set fleet "Small Southern Pirates" 500
+		set fleet "Large Southern Pirates" 800
 		add fleet "Small Core Pirates" 4000
 		add fleet "Large Core Pirates" 7000
 		add fleet "Small Northern Pirates" 5000
 		add fleet "Large Northern Pirates" 9000
-		"set period" fleet "Large Free Worlds" 9000
+		set fleet "Large Free Worlds" 9000
 
 
 
@@ -1049,14 +1049,14 @@ event "navy occupying the south"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		"set period" fleet "Small Southern Merchants" 1200
-		"set period" fleet "Large Southern Merchants" 2400
-		"set period" fleet "Small Republic" 500
+		set fleet "Small Southern Merchants" 1200
+		set fleet "Large Southern Merchants" 2400
+		set fleet "Small Republic" 500
 	system Girtab
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		"set period" fleet "Small Southern Merchants" 900
-		"set period" fleet "Large Southern Merchants" 2000
+		set fleet "Small Southern Merchants" 900
+		set fleet "Large Southern Merchants" 2000
 		add fleet "Small Republic" 500
 		add fleet "Large Republic" 700
 	system Albaldah
@@ -1064,15 +1064,15 @@ event "navy occupying the south"
 		remove fleet "Large Militia"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		"set period" fleet "Small Southern Merchants" 1000
-		"set period" fleet "Large Southern Merchants" 1200
+		set fleet "Small Southern Merchants" 1000
+		set fleet "Large Southern Merchants" 1200
 		add fleet "Small Republic" 500
 		add fleet "Large Republic" 700
 	system "Delta Sagittarii"
 		remove fleet "Small Militia"
 		remove fleet "Small Southern Pirates"
-		"set period" fleet "Small Southern Merchants" 1200
-		"set period" fleet "Large Southern Merchants" 4000
+		set fleet "Small Southern Merchants" 1200
+		set fleet "Large Southern Merchants" 4000
 		add fleet "Small Republic" 500
 		add fleet "Large Republic" 700
 
@@ -1199,7 +1199,7 @@ event "fw southern expansion"
 		government "Free Worlds"
 		add fleet "Small Southern Merchants" 1200
 		add fleet "Large Southern Merchants" 2400
-		"set period" fleet "Small Free Worlds" 500
+		set fleet "Small Free Worlds" 500
 		add fleet "Large Free Worlds" 700
 		add fleet "Small Southern Pirates" 3000
 		add fleet "Large Southern Pirates" 7000
@@ -1233,8 +1233,8 @@ event "fw southern expansion"
 	system "Kaus Borealis"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Navy Surveillance"
-		"set period" fleet "Small Republic" 400
-		"set period" fleet "Large Republic" 500
+		set fleet "Small Republic" 400
+		set fleet "Large Republic" 500
 	planet "New Iceland"
 		add description `	In the wake of their defeat in the south, the Navy has begun to set up a massive new base here on New Iceland, in order to allow them to continue to have a strong presence in this sector.`
 
@@ -1246,16 +1246,16 @@ event "fw occupying the north"
 		remove fleet "Large Southern Pirates"
 		add fleet "Small Free Worlds" 500
 		add fleet "Large Free Worlds" 800
-		"set period" fleet "Small Republic" 5000
-		"set period" fleet "Large Republic" 6000
-		"set period" fleet "Navy Surveillance" 4000
+		set fleet "Small Republic" 5000
+		set fleet "Large Republic" 6000
+		set fleet "Navy Surveillance" 4000
 	system Alphecca
 		remove fleet "Small Southern Pirates"
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
 		add fleet "Small Free Worlds" 1200
 		add fleet "Large Free Worlds" 2000
-		"set period" fleet "Navy Surveillance" 6000
+		set fleet "Navy Surveillance" 6000
 	system Boral
 		remove fleet "Small Southern Pirates"
 		remove fleet "Small Republic"
@@ -1267,16 +1267,16 @@ event "fw occupying the north"
 		remove fleet "Small Southern Pirates"
 		add fleet "Small Free Worlds" 700
 		add fleet "Large Free Worlds" 1100
-		"set period" fleet "Small Republic" 5000
-		"set period" fleet "Large Republic" 6000
-		"set period" fleet "Navy Surveillance" 4000
+		set fleet "Small Republic" 5000
+		set fleet "Large Republic" 6000
+		set fleet "Navy Surveillance" 4000
 	system Wei
 		remove fleet "Small Southern Pirates"
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
 		add fleet "Small Free Worlds" 800
 		add fleet "Large Free Worlds" 1000
-		"set period" fleet "Navy Surveillance" 4000
+		set fleet "Navy Surveillance" 4000
 
 
 
@@ -1331,7 +1331,7 @@ event "liberation of Poisonwood"
 		add fleet "Small Southern Merchants" 1000
 		add fleet "Large Southern Merchants" 4000
 		add fleet "Small Southern Pirates" 6000
-		"set period" fleet "Small Free Worlds" 700
+		set fleet "Small Free Worlds" 700
 		add fleet "Large Free Worlds" 1200
 		add fleet "Human Miners" 2000
 
@@ -1341,7 +1341,7 @@ event "Poisonwood reverts to Republic"
 		add fleet "Small Southern Merchants" 1000
 		add fleet "Large Southern Merchants" 4000
 		add fleet "Small Southern Pirates" 4000
-		"set period" fleet "Small Free Worlds" 1500
+		set fleet "Small Free Worlds" 1500
 		add fleet "Large Free Worlds" 2600
 		add fleet "Human Miners" 2000
 
@@ -1384,9 +1384,9 @@ event "bloodsea joins free worlds"
 		add fleet "Small Southern Merchants" 700
 		add fleet "Large Southern Merchants" 1400
 		add fleet "Small Free Worlds" 500
-		"set period" fleet "Large Free Worlds" 3000
-		"set period" fleet "Small Southern Pirates" 2000
-		"set period" fleet "Large Southern Pirates" 5000
+		set fleet "Large Free Worlds" 3000
+		set fleet "Small Southern Pirates" 2000
+		set fleet "Large Southern Pirates" 5000
 
 
 
@@ -1404,7 +1404,7 @@ event "battle for bloodsea"
 		remove fleet "Large Militia"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		"set period" fleet "Large Free Worlds" 10000
+		set fleet "Large Free Worlds" 10000
 
 
 
@@ -1418,7 +1418,7 @@ event "bloodsea independent"
 		add fleet "Small Southern Pirates" 1600
 		add fleet "Large Southern Pirates" 3000
 		add fleet "Small Free Worlds" 800
-		"set period" fleet "Large Free Worlds" 1500
+		set fleet "Large Free Worlds" 1500
 	planet Bloodsea
 		description `Bloodsea is nearly uninhabited, except for a few small outposts. Its name comes from the planet's oceans, which are blood-red due to rhodophyte algae. Although the climate is temperate and there are many white sand beaches, no one comes here hoping to go swimming.`
 		description `	Until recently, this was a pirate world, but they are now officially "independent," forswearing support for piracy and other criminal activity as a result of being dominated by the Free Worlds militia. You get the feeling that most of the locals are not too fond of the Free Worlds, however.`
@@ -1432,12 +1432,12 @@ event "albatross joins free worlds"
 	system Nunki
 		government "Free Worlds"
 		remove fleet "Small Militia"
-		"set period" fleet "Small Southern Merchants" 700
+		set fleet "Small Southern Merchants" 700
 		add fleet "Large Southern Merchants" 1400
 		add fleet "Small Free Worlds" 500
 		add fleet "Large Free Worlds" 3000
-		"set period" fleet "Small Southern Pirates" 2000
-		"set period" fleet "Large Southern Pirates" 5000
+		set fleet "Small Southern Pirates" 2000
+		set fleet "Large Southern Pirates" 5000
 
 
 
@@ -1447,7 +1447,7 @@ event "battle for zeta aquilae"
 		remove fleet "Large Southern Merchants"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
-		"set period" fleet "Small Southern Merchants" 5000
+		set fleet "Small Southern Merchants" 5000
 
 
 
@@ -1468,52 +1468,52 @@ event "fw expanded and cut"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		"set period" fleet "Small Southern Merchants" 2000
-		"set period" fleet "Large Southern Merchants" 6000
+		set fleet "Small Southern Merchants" 2000
+		set fleet "Large Southern Merchants" 6000
 		add fleet "Small Republic" 500
 		add fleet "Large Republic" 700
-		"set period" fleet "Large Free Worlds" 3000
-		"set period" fleet "Human Miners" 6000
+		set fleet "Large Free Worlds" 3000
+		set fleet "Human Miners" 6000
 	system Rastaban
 		government Republic
 		remove fleet "Small Free Worlds"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		"set period" fleet "Small Southern Merchants" 1000
-		"set period" fleet "Large Southern Merchants" 4000
+		set fleet "Small Southern Merchants" 1000
+		set fleet "Large Southern Merchants" 4000
 		add fleet "Small Republic" 700
 		add fleet "Large Republic" 900
-		"set period" fleet "Large Free Worlds" 2000
+		set fleet "Large Free Worlds" 2000
 	system Girtab
 		government Republic
 		remove fleet "Small Free Worlds"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		"set period" fleet "Small Southern Merchants" 1000
-		"set period" fleet "Large Southern Merchants" 3000
+		set fleet "Small Southern Merchants" 1000
+		set fleet "Large Southern Merchants" 3000
 		add fleet "Small Republic" 900
 		add fleet "Large Republic" 1200
-		"set period" fleet "Large Free Worlds" 1800
+		set fleet "Large Free Worlds" 1800
 	system Lesath
 		remove fleet "Small Free Worlds"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		"set period" fleet "Small Southern Merchants" 6000
-		"set period" fleet "Large Southern Merchants" 9000
+		set fleet "Small Southern Merchants" 6000
+		set fleet "Large Southern Merchants" 9000
 		add fleet "Small Republic" 1000
 		add fleet "Large Republic" 1000
-		"set period" fleet "Large Free Worlds" 800
+		set fleet "Large Free Worlds" 800
 	system "Alpha Arae"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		"set period" fleet "Small Southern Merchants" 5000
-		"set period" fleet "Large Southern Merchants" 6000
-		"set period" fleet "Small Republic" 800
-		"set period" fleet "Large Republic" 1000
+		set fleet "Small Southern Merchants" 5000
+		set fleet "Large Southern Merchants" 6000
+		set fleet "Small Republic" 800
+		set fleet "Large Republic" 1000
 		add fleet "Large Free Worlds" 3000
 
 
@@ -1585,11 +1585,11 @@ event "fw empty gienah"
 	system Gienah
 		remove fleet "Large Syndicate"
 		remove fleet "Large Core Pirates"
-		"set period" fleet "Small Core Pirates" 5000
+		set fleet "Small Core Pirates" 5000
 
 event "fw restore gienah"
 	system Gienah
-		"set period" fleet "Small Core Pirates" 500
+		set fleet "Small Core Pirates" 500
 		add fleet "Large Core Pirates" 800
 		add fleet "Large Syndicate" 5000
 
@@ -1600,10 +1600,10 @@ event "navy out of rastaban"
 		government "Free Worlds"
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
-		"set period" fleet "Small Southern Merchants" 1200
-		"set period" fleet "Large Southern Merchants" 2400
+		set fleet "Small Southern Merchants" 1200
+		set fleet "Large Southern Merchants" 2400
 		add fleet "Small Free Worlds" 500
-		"set period" fleet "Large Free Worlds" 700
+		set fleet "Large Free Worlds" 700
 		add fleet "Small Southern Pirates" 3000
 		add fleet "Large Southern Pirates" 7000
 		add fleet "Navy Surveillance" 2000
@@ -1611,10 +1611,10 @@ event "navy out of rastaban"
 		government Neutral
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
-		"set period" fleet "Small Southern Merchants" 900
-		"set period" fleet "Large Southern Merchants" 2000
+		set fleet "Small Southern Merchants" 900
+		set fleet "Large Southern Merchants" 2000
 		add fleet "Small Free Worlds" 1000
-		"set period" fleet "Large Free Worlds" 1700
+		set fleet "Large Free Worlds" 1700
 		add fleet "Small Southern Pirates" 3000
 		add fleet "Large Southern Pirates" 7000
 		add fleet "Navy Surveillance" 5000
@@ -1622,32 +1622,32 @@ event "navy out of rastaban"
 		government "Free Worlds"
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
-		"set period" fleet "Small Southern Merchants" 1200
-		"set period" fleet "Large Southern Merchants" 4000
+		set fleet "Small Southern Merchants" 1200
+		set fleet "Large Southern Merchants" 4000
 		add fleet "Small Free Worlds" 600
-		"set period" fleet "Large Free Worlds" 900
+		set fleet "Large Free Worlds" 900
 		add fleet "Small Southern Pirates" 3000
 		add fleet "Large Southern Pirates" 7000
 		add fleet "Navy Surveillance" 3000
-		"set period" fleet "Human Miners" 4000
+		set fleet "Human Miners" 4000
 	system Lesath
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
-		"set period" fleet "Small Southern Merchants" 800
-		"set period" fleet "Large Southern Merchants" 1600
-		"set period" fleet "Small Free Worlds" 800
-		"set period" fleet "Large Free Worlds" 1100
+		set fleet "Small Southern Merchants" 800
+		set fleet "Large Southern Merchants" 1600
+		set fleet "Small Free Worlds" 800
+		set fleet "Large Free Worlds" 1100
 		add fleet "Small Southern Pirates" 2000
 		add fleet "Large Southern Pirates" 5000
 		add fleet "Navy Surveillance" 4000
 	system "Alpha Arae"
 		remove fleet "Large Free Worlds"
-		"set period" fleet "Small Southern Merchants" 2100
-		"set period" fleet "Large Southern Merchants" 8000
+		set fleet "Small Southern Merchants" 2100
+		set fleet "Large Southern Merchants" 8000
 		add fleet "Small Southern Pirates" 6000
 		add fleet "Large Southern Pirates" 13000
-		"set period" fleet "Small Republic" 900
-		"set period" fleet "Large Republic" 800
+		set fleet "Small Republic" 900
+		set fleet "Large Republic" 800
 		add fleet "Navy Surveillance" 1200
 
 
@@ -1664,12 +1664,12 @@ event "stack core for sale"
 
 event "syndicate occupies sol"
 	system Sol
-		"set period" fleet "Small Northern Merchants" 500
-		"set period" fleet "Large Northern Merchants" 700
-		"set period" fleet "Small Republic" 800
-		"set period" fleet "Large Republic" 1200
-		"set period" fleet "Small Core Merchants" 900
-		"set period" fleet "Large Core Merchants" 1400
+		set fleet "Small Northern Merchants" 500
+		set fleet "Large Northern Merchants" 700
+		set fleet "Small Republic" 800
+		set fleet "Large Republic" 1200
+		set fleet "Small Core Merchants" 900
+		set fleet "Large Core Merchants" 1400
 		add fleet "Small Syndicate" 400
 		add fleet "Large Syndicate" 600
 
@@ -1690,7 +1690,7 @@ event "pug invasion"
 	unvisit Peacock
 	system "Zeta Aquilae"
 		government Pug
-		"set period" fleet "Small Southern Merchants" 1000
+		set fleet "Small Southern Merchants" 1000
 		add fleet "Large Southern Merchants" 3000
 		add fleet "Small Pug" 1000
 		add fleet "Large Pug" 2000
@@ -1732,8 +1732,8 @@ event "pug invasion 2"
 		government Pug
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
-		"set period" fleet "Small Northern Merchants" 800
-		"set period" fleet "Large Northern Merchants" 3000
+		set fleet "Small Northern Merchants" 800
+		set fleet "Large Northern Merchants" 3000
 		add fleet "Small Pug" 800
 		add fleet "Large Pug" 1200
 	system Altair
@@ -1807,12 +1807,12 @@ event "pug invasion 4"
 	system Sol
 		remove fleet "Small Syndicate"
 		remove fleet "Large Syndicate"
-		"set period" fleet "Small Northern Merchants" 300
-		"set period" fleet "Large Northern Merchants" 500
-		"set period" fleet "Small Republic" 600
-		"set period" fleet "Large Republic" 900
-		"set period" fleet "Small Core Merchants" 1000
-		"set period" fleet "Large Core Merchants" 2000
+		set fleet "Small Northern Merchants" 300
+		set fleet "Large Northern Merchants" 500
+		set fleet "Small Republic" 600
+		set fleet "Large Republic" 900
+		set fleet "Small Core Merchants" 1000
+		set fleet "Large Core Merchants" 2000
 	system Diphda
 		government Pug
 		remove fleet "Small Syndicate"
@@ -1842,8 +1842,8 @@ event "fw syndicate welcoming"
 		government "Syndicate (Extremist)"
 		remove fleet "Small Core Merchants"
 		remove fleet "Large Syndicate"
-		"set period" fleet "Small Core Pirates" 1500
-		"set period" fleet "Large Core Pirates" 2000
+		set fleet "Small Core Pirates" 1500
+		set fleet "Large Core Pirates" 2000
 		add fleet "Syndicate Extremists" 200
 
 
@@ -1860,8 +1860,8 @@ event "at war with the pug"
 		remove fleet "Large Core Merchants"
 		remove fleet "Small Pug"
 		remove fleet "Large Pug"
-		"set period" fleet "Small Core Merchants" 1500
-		"set period" fleet "Human Miners" 6000
+		set fleet "Small Core Merchants" 1500
+		set fleet "Human Miners" 6000
 
 
 
@@ -1877,7 +1877,7 @@ event "reconnected delta capricorni"
 		add fleet "Large Core Merchants" 3000
 		add fleet "Small Pug" 2000
 		add fleet "Large Syndicate" 400
-		"set period" fleet "Human Miners" 3000
+		set fleet "Human Miners" 3000
 
 
 
@@ -1888,14 +1888,14 @@ event "battle for altair"
 		remove fleet "Large Northern Merchants"
 		remove fleet "Small Pug"
 		remove fleet "Large Pug"
-		"set period" fleet "Small Core Merchants" 1500
+		set fleet "Small Core Merchants" 1500
 
 
 
 event "liberation of altair"
 	system Altair
 		government Republic
-		"set period" fleet "Small Core Merchants" 1000
+		set fleet "Small Core Merchants" 1000
 		add fleet "Large Core Merchants" 2000
 		add fleet "Small Pug" 2000
 		add fleet "Large Syndicate" 800
@@ -1908,8 +1908,8 @@ event "reconnected altair"
 		government Republic
 		remove fleet "Small Pug"
 		remove fleet "Large Syndicate"
-		"set period" fleet "Small Core Merchants" 800
-		"set period" fleet "Large Core Merchants" 1200
+		set fleet "Small Core Merchants" 800
+		set fleet "Large Core Merchants" 1200
 
 
 
@@ -2097,7 +2097,7 @@ event "navy occupies algenib"
 		remove fleet "Large Core Pirates"
 		add fleet "Small Republic" 800
 		add fleet "Large Republic" 1200
-		"set period" fleet "Large Syndicate" 1000
+		set fleet "Large Syndicate" 1000
 
 
 
@@ -2115,7 +2115,7 @@ event "navy done with algenib"
 		remove fleet "Large Republic"
 		add fleet "Small Core Pirates" 500
 		add fleet "Large Core Pirates" 800
-		"set period" fleet "Large Syndicate" 5000
+		set fleet "Large Syndicate" 5000
 
 
 
@@ -2126,7 +2126,7 @@ event "fwc southern battle"
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
 		remove fleet "Human Miners"
-		"set period" fleet "Large Free Worlds" 4000
+		set fleet "Large Free Worlds" 4000
 	system Rastaban
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
@@ -2144,14 +2144,14 @@ event "fwc southern liberation"
 		add fleet "Small Southern Merchants" 1200
 		add fleet "Large Southern Merchants" 4000
 		add fleet "Small Free Worlds" 600
-		"set period" fleet "Large Free Worlds" 900
+		set fleet "Large Free Worlds" 900
 		add fleet "Small Southern Pirates" 3000
 		add fleet "Large Southern Pirates" 7000
 		add fleet "Large Republic" 3000
 		add fleet "Human Miners" 4000
 	system Rastaban
 		government "Free Worlds"
-		"set period" fleet "Small Southern Merchants" 1200
+		set fleet "Small Southern Merchants" 1200
 		add fleet "Large Southern Merchants" 6000
 		add fleet "Small Free Worlds" 500
 		add fleet "Large Free Worlds" 700
@@ -2160,17 +2160,17 @@ event "fwc southern liberation"
 		add fleet "Large Republic" 3000
 	system Girtab
 		government Neutral
-		"set period" fleet "Small Southern Merchants" 900
-		"set period" fleet "Large Southern Merchants" 2000
+		set fleet "Small Southern Merchants" 900
+		set fleet "Large Southern Merchants" 2000
 		add fleet "Small Free Worlds" 1000
 		add fleet "Large Free Worlds" 1700
 		add fleet "Small Southern Pirates" 3000
 		add fleet "Large Southern Pirates" 7000
 	system Lesath
-		"set period" fleet "Small Southern Merchants" 800
-		"set period" fleet "Large Southern Merchants" 1600
+		set fleet "Small Southern Merchants" 800
+		set fleet "Large Southern Merchants" 1600
 		add fleet "Small Free Worlds" 800
-		"set period" fleet "Large Free Worlds" 1100
+		set fleet "Large Free Worlds" 1100
 		add fleet "Small Southern Pirates" 2000
 		add fleet "Large Southern Pirates" 5000
 		add fleet "Navy Surveillance" 4000
@@ -2198,7 +2198,7 @@ event "fwc capture kaus borealis"
 		government "Free Worlds"
 		add fleet "Small Southern Merchants" 2000
 		add fleet "Small Free Worlds" 400
-		"set period" fleet "Large Free Worlds" 400
+		set fleet "Large Free Worlds" 400
 		add fleet "Large Republic" 2000
 	planet "New Iceland"
 		description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds. Many of the inhabitants wear dust masks to avoid letting the particulate matter from the volcanoes accumulate in their lungs.`
@@ -2211,24 +2211,24 @@ event "fwc attack cebalrai"
 		remove fleet "Small Republic"
 		remove fleet "Large Republic"
 		remove fleet "Navy Surveillance"
-		"set period" fleet "Small Southern Merchants" 5000
-		"set period" fleet "Large Southern Merchants" 6000
+		set fleet "Small Southern Merchants" 5000
+		set fleet "Large Southern Merchants" 6000
 
 
 
 event "fwc capture cebalrai"
 	system Cebalrai
 		government "Free Worlds"
-		"set period" fleet "Small Southern Merchants" 1000
-		"set period" fleet "Large Southern Merchants" 1500
+		set fleet "Small Southern Merchants" 1000
+		set fleet "Large Southern Merchants" 1500
 		add fleet "Small Free Worlds" 400
 		add fleet "Large Free Worlds" 400
 		add fleet "Large Republic" 2000
 	system "Kaus Borealis"
 		government "Free Worlds"
 		remove fleet "Large Republic"
-		"set period" fleet "Small Free Worlds" 600
-		"set period" fleet "Large Free Worlds" 700
+		set fleet "Small Free Worlds" 600
+		set fleet "Large Free Worlds" 700
 
 
 
@@ -2244,7 +2244,7 @@ event "fwc defend cebalrai"
 		remove fleet "Large Southern Merchants"
 		remove fleet "Small Free Worlds"
 		remove fleet "Large Republic"
-		"set period" fleet "Large Free Worlds" 6000
+		set fleet "Large Free Worlds" 6000
 
 
 
@@ -2253,7 +2253,7 @@ event "fwc defended cebalrai"
 		add fleet "Small Southern Merchants" 1000
 		add fleet "Large Southern Merchants" 1500
 		add fleet "Small Free Worlds" 500
-		"set period" fleet "Large Free Worlds" 600
+		set fleet "Large Free Worlds" 600
 		add fleet "Large Republic" 5000
 	system Sargas
 		remove fleet "Navy Surveillance"
@@ -2262,9 +2262,9 @@ event "fwc defended cebalrai"
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"
 		remove fleet "Navy Surveillance"
-		"set period" fleet "Small Southern Merchants" 6000
-		"set period" fleet "Large Southern Merchants" 9000
-		"set period" fleet "Large Free Worlds" 800
+		set fleet "Small Southern Merchants" 6000
+		set fleet "Large Southern Merchants" 9000
+		set fleet "Large Free Worlds" 800
 	system Dschubba
 		remove fleet "Navy Surveillance"
 	system Seginus
@@ -2302,14 +2302,14 @@ event "fwc attack menkent"
 		remove fleet "Large Republic"
 		remove fleet "Navy Surveillance"
 		remove fleet "Human Miners"
-		"set period" fleet "Small Southern Merchants" 5000
+		set fleet "Small Southern Merchants" 5000
 
 
 
 event "fwc capture menkent"
 	system Menkent
 		government "Free Worlds"
-		"set period" fleet "Small Southern Merchants" 700
+		set fleet "Small Southern Merchants" 700
 		add fleet "Large Southern Merchants" 1900
 		add fleet "Small Free Worlds" 300
 		add fleet "Large Free Worlds" 400
@@ -2354,7 +2354,7 @@ event "fwc pug invasion"
 			"Free Worlds" -.01
 	system "Zeta Aquilae"
 		government Pug
-		"set period" fleet "Small Southern Merchants" 1000
+		set fleet "Small Southern Merchants" 1000
 		add fleet "Large Southern Merchants" 3000
 		add fleet "Small Pug" 1000
 		add fleet "Large Pug" 2000
@@ -2438,14 +2438,14 @@ event "fwc navy retakes cebalrai"
 		government Republic
 		remove fleet "Small Free Worlds"
 		add fleet "Small Republic" 500
-		"set period" fleet "Large Republic" 600
-		"set period" fleet "Large Free Worlds" 5000
+		set fleet "Large Republic" 600
+		set fleet "Large Free Worlds" 5000
 	system Menkent
 		government Republic
 		remove fleet "Small Free Worlds"
 		add fleet "Small Republic" 300
-		"set period" fleet "Large Republic" 400
-		"set period" fleet "Large Free Worlds" 2000
+		set fleet "Large Republic" 400
+		set fleet "Large Free Worlds" 2000
 
 
 
@@ -2502,7 +2502,7 @@ event "fwc battle for rasalhague"
 		remove fleet "Large Southern Merchants"
 		remove fleet "Small Pug"
 		remove fleet "Large Pug"
-		"set period" fleet "Small Southern Merchants" 10000
+		set fleet "Small Southern Merchants" 10000
 	government Pug
 		"attitude toward"
 			"Free Worlds" -.01
@@ -2514,7 +2514,7 @@ event "fwc battle for rasalhague"
 event "fwc liberation of rasalhague"
 	system Rasalhague
 		government "Free Worlds"
-		"set period" fleet "Small Southern Merchants" 1500
+		set fleet "Small Southern Merchants" 1500
 		add fleet "Large Southern Merchants" 2000
 		add fleet "Small Republic" 400
 		add fleet "Large Republic" 600
@@ -2543,8 +2543,8 @@ event "fwc liberation of rasalhague"
 		remove fleet "Large Pug"
 	system Deneb
 		add fleet "Small Core Merchants" 10000
-		"set period" fleet "Small Pug" 100
-		"set period" fleet "Large Pug" 100
+		set fleet "Small Pug" 100
+		set fleet "Large Pug" 100
 
 
 
@@ -2557,7 +2557,7 @@ event "fwc reconnect zeta aquilae"
 	link "Zeta Aquilae" Ascella
 	system "Zeta Aquilae"
 		government "Free Worlds"
-		"set period" fleet "Small Southern Merchants" 1500
+		set fleet "Small Southern Merchants" 1500
 		add fleet "Large Southern Merchants" 6000
 		add fleet "Small Republic" 400
 		add fleet "Large Republic" 600

--- a/data/events.txt
+++ b/data/events.txt
@@ -469,83 +469,119 @@ event "initial deployment 2"
 event "initial deployment 3"
 	date 29 8 3014
 	system Zubenelgenubi
-		fleet "Small Southern Merchants" 500
-		fleet "Large Southern Merchants" 900
-		fleet "Small Free Worlds" 800
-		fleet "Large Free Worlds" 1000
-		fleet "Small Southern Pirates" 5000
-		fleet "Large Southern Pirates" 8000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Large Southern Merchants" 2250
+		add fleet "Small Free Worlds" 800
+		add fleet "Large Free Worlds" 1000
+		add fleet "Small Southern Pirates" 5000
+		add fleet "Large Southern Pirates" 8000
 	system Unukalhai
-		fleet "Small Southern Merchants" 900
-		fleet "Large Southern Merchants" 3000
-		fleet "Small Southern Pirates" 3000
-		fleet "Small Free Worlds" 3000
-		fleet "Large Free Worlds" 6000
-		fleet "Human Miners" 3000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		add fleet "Small Southern Merchants" 9000
+		add fleet "Large Southern Merchants" 12000
+		add fleet "Small Free Worlds" 3000
+		add fleet "Large Free Worlds" 6000
 	system Sabik
-		fleet "Small Southern Merchants" 400
-		fleet "Large Southern Merchants" 600
-		fleet "Small Free Worlds" 1000
-		fleet "Large Free Worlds" 1600
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		add fleet "Large Southern Merchants" 1800
+		add fleet "Small Free Worlds" 1000
+		add fleet "Large Free Worlds" 1600
 	system Aldhibain
-		fleet "Small Southern Merchants" 400
-		fleet "Large Southern Merchants" 500
-		fleet "Small Free Worlds" 600
-		fleet "Large Free Worlds" 700
-		fleet "Small Southern Pirates" 1400
-		fleet "Large Southern Pirates" 3000
-		fleet "Human Miners" 3000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Large Southern Merchants" 3000
+		add fleet "Small Free Worlds" 600
+		add fleet "Large Free Worlds" 700
+		add fleet "Small Southern Pirates" 1400
+		add fleet "Large Southern Pirates" 3000
 	system Kornephoros
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 700
-		fleet "Small Southern Pirates" 5000
-		fleet "Small Free Worlds" 1000
-		fleet "Large Free Worlds" 2000
-		fleet "Human Miners" 3000
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Pirates"
+		add fleet "Large Southern Merchants" 1680
+		add fleet "Small Southern Pirates" 5000
+		add fleet "Small Free Worlds" 1000
+		add fleet "Large Free Worlds" 2000
 	
 	system Wei
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 2500
-		fleet "Small Southern Pirates" 6000
-		fleet "Small Republic" 800
-		fleet "Large Republic" 700
-		fleet "Navy Surveillance" 1200
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		add fleet "Small Southern Merchants" 800
+		add fleet "Large Southern Merchants" 2500
+		add fleet "Small Southern Pirates" 6000
+		add fleet "Small Republic" 800
+		add fleet "Large Republic" 700
+		add fleet "Navy Surveillance" 1200
 	system Seginus
-		fleet "Small Southern Merchants" 1200
-		fleet "Large Southern Merchants" 2700
-		fleet "Small Southern Pirates" 8000
-		fleet "Small Republic" 1200
-		fleet "Large Republic" 1400
-		fleet "Navy Surveillance" 1200
+		remove fleet "Small Militia"
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		add fleet "Small Southern Merchants" 1200
+		add fleet "Large Southern Merchants" 2700
+		add fleet "Small Southern Pirates" 8000
+		add fleet "Small Republic" 1200
+		add fleet "Large Republic" 1400
+		add fleet "Navy Surveillance" 1200
 	system Alnasl
-		fleet "Small Southern Merchants" 1300
-		fleet "Large Southern Merchants" 2500
-		fleet "Small Southern Pirates" 6000
-		fleet "Small Republic" 900
-		fleet "Large Republic" 1100
-		fleet "Navy Surveillance" 1200
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		add fleet "Small Southern Merchants" 1300
+		add fleet "Large Southern Merchants" 2500
+		add fleet "Small Southern Pirates" 6000
+		add fleet "Small Republic" 900
+		add fleet "Large Republic" 1100
+		add fleet "Navy Surveillance" 1200
 	system Eber
-		fleet "Small Southern Merchants" 1900
-		fleet "Large Southern Merchants" 2900
-		fleet "Small Southern Pirates" 3000
-		fleet "Small Republic" 1000
-		fleet "Large Republic" 1500
-		fleet "Navy Surveillance" 1200
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		add fleet "Small Southern Merchants" 1900
+		add fleet "Large Southern Merchants" 2900
+		add fleet "Small Southern Pirates" 3000
+		add fleet "Small Republic" 1000
+		add fleet "Large Republic" 1500
+		add fleet "Navy Surveillance" 1200
 	system "Alpha Arae"
-		fleet "Small Southern Merchants" 2100
-		fleet "Large Southern Merchants" 8000
-		fleet "Small Southern Pirates" 6000
-		fleet "Large Southern Pirates" 13000
-		fleet "Small Republic" 900
-		fleet "Large Republic" 800
-		fleet "Navy Surveillance" 1200
+		remove fleet "Small Militia"
+		remove fleet "Large Militia"
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		add fleet "Small Southern Merchants" 2100
+		add fleet "Large Southern Merchants" 8000
+		add fleet "Small Southern Pirates" 6000
+		add fleet "Large Southern Pirates" 13000
+		add fleet "Small Republic" 900
+		add fleet "Large Republic" 800
+		add fleet "Navy Surveillance" 1200
 	system "Kaus Borealis"
-		fleet "Small Southern Merchants" 900
-		fleet "Large Southern Merchants" 4000
-		fleet "Small Southern Pirates" 8000
-		fleet "Small Republic" 1100
-		fleet "Large Republic" 800
-		fleet "Navy Surveillance" 1200
+		remove fleet "Small Militia"
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Southern Pirates"
+		add fleet "Small Southern Merchants" 900
+		add fleet "Large Southern Merchants" 4000
+		add fleet "Small Southern Pirates" 8000
+		add fleet "Small Republic" 1100
+		add fleet "Large Republic" 800
+		add fleet "Navy Surveillance" 1200
 
 mission "Southern Carriers Trigger"
 	landing

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1884,47 +1884,35 @@ mission "FW Rand 1B"
 
 event "battle of alioth"
 	system Rutilicus
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Southern Pirates" 8000
-		fleet "Small Republic" 1000
-		fleet "Human Miners" 3000
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
 	system Cebalrai
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Southern Pirates" 4000
-		fleet "Small Republic" 1000
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+	system Holeb
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
 	system Alioth
-		fleet "Small Southern Merchants" 400
-		fleet "Large Northern Merchants" 600
-		fleet "Small Southern Pirates" 1200
-		fleet "Large Southern Pirates" 2400
-		fleet "Small Republic" 3000
-			
+		remove fleet "Small Free Worlds"
+		remove fleet "Large Free Worlds"
+		remove fleet "Large Republic"
+		add fleet "Small Southern Pirates" 1200
+		add fleet "Large Southern Pirates" 2400
+		add fleet "Small Republic" 7500
+
 event "end battle of alioth"
 	system Rutilicus
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Southern Pirates" 8000
-		fleet "Small Republic" 1000
-		fleet "Large Republic" 2000
-		fleet "Navy Surveillance" 1600
-		fleet "Human Miners" 3000
+		add fleet "Large Republic" 2000
+		add fleet "Navy Surveillance" 1600
 	system Cebalrai
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2000
-		fleet "Small Southern Pirates" 4000
-		fleet "Small Republic" 1000
-		fleet "Large Republic" 2000
-		fleet "Navy Surveillance" 1600
+		add fleet "Large Republic" 2000
+		add fleet "Navy Surveillance" 1600
+	system Holeb
+		add fleet "Large Republic" 3000
+		add fleet "Navy Surveillance" 1600
 	system Alioth
-		fleet "Small Southern Merchants" 400
-		fleet "Large Northern Merchants" 600
-		fleet "Small Southern Pirates" 1200
-		fleet "Large Southern Pirates" 2400
-		fleet "Small Republic" 3000
-		fleet "Large Republic" 4000
-		fleet "Navy Surveillance" 1600
+		add fleet "Large Republic" 4000
+		add fleet "Navy Surveillance" 1600
 
 
 

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -311,7 +311,11 @@ mission "FW Southern Battle 1B"
 event "battle for Rastaban"
 	"reputation: Republic" = -1000
 	system Rastaban
-		fleet "Small Free Worlds" 10000
+		remove fleet "Small Southern Merchants"
+		remove fleet "Large Southern Merchants"
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		add fleet "Small Free Worlds" 10000
 	system Lesath
 		remove fleet "Small Southern Pirates"
 		remove fleet "Large Southern Pirates"

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1895,6 +1895,7 @@ event "battle of alioth"
 		fleet "Large Southern Merchants" 2000
 		fleet "Small Southern Pirates" 8000
 		fleet "Small Republic" 1000
+		fleet "Human Miners" 3000
 	system Cebalrai
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 2000
@@ -1915,6 +1916,7 @@ event "end battle of alioth"
 		fleet "Small Republic" 1000
 		fleet "Large Republic" 2000
 		fleet "Navy Surveillance" 1600
+		fleet "Human Miners" 3000
 	system Cebalrai
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 2000

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -1745,11 +1745,6 @@ mission "FW Albatross 2B"
 
 
 
-event "battle for zeta aquilae"
-	"reputation: Republic" = -1000
-	system "Zeta Aquilae"
-		fleet "Small Southern Merchants" 5000
-
 mission "FW Rand 1"
 	landing
 	name "Occupy Zeta Aquilae"

--- a/data/free worlds middle.txt
+++ b/data/free worlds middle.txt
@@ -313,15 +313,13 @@ event "battle for Rastaban"
 	system Rastaban
 		fleet "Small Free Worlds" 10000
 	system Lesath
-		fleet "Small Southern Merchants" 800
-		fleet "Large Southern Merchants" 1600
-		fleet "Small Free Worlds" 800
-		fleet "Large Free Worlds" 1100
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Navy Surveillance"
 	system Sargas
-		fleet "Small Southern Merchants" 600
-		fleet "Large Southern Merchants" 2500
-		fleet "Small Free Worlds" 1000
-		fleet "Large Free Worlds" 1500
+		remove fleet "Small Southern Pirates"
+		remove fleet "Large Southern Pirates"
+		remove fleet "Navy Surveillance"
 
 mission "FW Southern Battle 2"
 	name "Attack Rastaban"

--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -90,16 +90,6 @@ mission "FW Reconciliation 1"
 
 
 
-event "fw empty gienah"
-	system Gienah
-		fleet "Small Core Pirates" 5000
-
-event "fw restore gienah"
-	system Gienah
-		fleet "Small Core Pirates" 500
-		fleet "Large Core Pirates" 800
-		fleet "Large Syndicate" 5000
-
 mission "FW Reconciliation 1B"
 	name "Travel to <planet>"
 	description "Bring Ijs, Sawyer, and Katya to <system>. Destroy any Syndicate ships that are watching you, then land on <planet>. Make sure Raven's ship arrives there as well. You may need to bribe Syndicate worlds to let you refuel."

--- a/data/free worlds side plots.txt
+++ b/data/free worlds side plots.txt
@@ -333,15 +333,13 @@ event "wolf pack 3 ready"
 
 event "wolf pack gacrux start"
 	system Gacrux
-		remove fleet "Small Republic"
 		remove fleet "Large Republic"
 		remove fleet "Navy Surveillance"
-		add fleet "Small Republic" 8000
+		"set period" fleet "Small Republic" 8000
 
 event "wolf pack gacrux end"
 	system Gacrux
-		remove fleet "Small Republic"
-		add fleet "Small Republic" 2000
+		"set period" fleet "Small Republic" 2000
 		add fleet "Large Republic" 3000
 		add fleet "Navy Surveillance" 1600
 
@@ -403,15 +401,13 @@ event "wolf pack 4 ready"
 
 event "wolf pack mizar start"
 	system Mizar
-		remove fleet "Small Republic"
 		remove fleet "Large Republic"
 		remove fleet "Navy Surveillance"
-		add fleet "Small Republic" 5000
+		"set period" fleet "Small Republic" 5000
 
 event "wolf pack mizar end"
 	system Mizar
-		remove fleet "Small Republic"
-		add fleet "Small Republic" 1000
+		"set period" fleet "Small Republic" 1000
 		add fleet "Large Republic" 1400
 		add fleet "Navy Surveillance" 2000
 

--- a/data/free worlds side plots.txt
+++ b/data/free worlds side plots.txt
@@ -333,21 +333,17 @@ event "wolf pack 3 ready"
 
 event "wolf pack gacrux start"
 	system Gacrux
-		fleet "Small Southern Merchants" 2000
-		fleet "Large Southern Merchants" 5000
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 4000
-		fleet "Small Republic" 8000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Republic" 8000
 
 event "wolf pack gacrux end"
 	system Gacrux
-		fleet "Small Southern Merchants" 2000
-		fleet "Large Southern Merchants" 5000
-		fleet "Small Southern Pirates" 2000
-		fleet "Large Southern Pirates" 4000
-		fleet "Small Republic" 2000
-		fleet "Large Republic" 3000
-		fleet "Navy Surveillance" 1600
+		remove fleet "Small Republic"
+		add fleet "Small Republic" 2000
+		add fleet "Large Republic" 3000
+		add fleet "Navy Surveillance" 1600
 
 
 
@@ -407,19 +403,17 @@ event "wolf pack 4 ready"
 
 event "wolf pack mizar start"
 	system Mizar
-		fleet "Small Southern Merchants" 1400
-		fleet "Large Southern Merchants" 4500
-		fleet "Small Republic" 5000
-		fleet "Small Southern Pirates" 9000
+		remove fleet "Small Republic"
+		remove fleet "Large Republic"
+		remove fleet "Navy Surveillance"
+		add fleet "Small Republic" 5000
 
 event "wolf pack mizar end"
 	system Mizar
-		fleet "Small Southern Merchants" 1400
-		fleet "Large Southern Merchants" 4500
-		fleet "Small Republic" 1000
-		fleet "Large Republic" 1400
-		fleet "Small Southern Pirates" 9000
-		fleet "Navy Surveillance" 2000
+		remove fleet "Small Republic"
+		add fleet "Small Republic" 1000
+		add fleet "Large Republic" 1400
+		add fleet "Navy Surveillance" 2000
 
 
 

--- a/data/free worlds side plots.txt
+++ b/data/free worlds side plots.txt
@@ -335,11 +335,11 @@ event "wolf pack gacrux start"
 	system Gacrux
 		remove fleet "Large Republic"
 		remove fleet "Navy Surveillance"
-		"set period" fleet "Small Republic" 8000
+		set fleet "Small Republic" 8000
 
 event "wolf pack gacrux end"
 	system Gacrux
-		"set period" fleet "Small Republic" 2000
+		set fleet "Small Republic" 2000
 		add fleet "Large Republic" 3000
 		add fleet "Navy Surveillance" 1600
 
@@ -403,11 +403,11 @@ event "wolf pack mizar start"
 	system Mizar
 		remove fleet "Large Republic"
 		remove fleet "Navy Surveillance"
-		"set period" fleet "Small Republic" 5000
+		set fleet "Small Republic" 5000
 
 event "wolf pack mizar end"
 	system Mizar
-		"set period" fleet "Small Republic" 1000
+		set fleet "Small Republic" 1000
 		add fleet "Large Republic" 1400
 		add fleet "Navy Surveillance" 2000
 

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -1500,12 +1500,6 @@ mission "FW Pirates 4"
 
 
 
-event "battle for Thule"
-	system Men
-		fleet "Small Southern Pirates" 10000
-
-
-
 mission "FW Pirates 4B"
 	name "Return to Longjump"
 	description "Escort the newly repaired F.S. Terebinth back to the Free Worlds base on <destination>."

--- a/data/free worlds start.txt
+++ b/data/free worlds start.txt
@@ -159,12 +159,6 @@ mission "Liberate Kornephoros"
 
 
 
-event "prepare for battle of Kornephoros"
-	system "Kornephoros"
-		fleet "Small Free Worlds" 10000
-
-
-
 mission "FW Prisoner Parole"
 	name "Prisoner Parole"
 	description "Escort a fleet of transports carrying prisoners of war to <planet>. The temporary ceasefire will end on <date>."

--- a/data/map.txt
+++ b/data/map.txt
@@ -2913,7 +2913,7 @@ system Alioth
 	trade Metal 537
 	trade Plastic 458
 	fleet "Small Southern Merchants" 400
-	fleet "Large Northern Merchants" 600
+	fleet "Large Southern Merchants" 600
 	fleet "Small Militia" 900
 	fleet "Small Southern Pirates" 1200
 	fleet "Large Southern Pirates" 2400
@@ -3710,7 +3710,7 @@ system Alphecca
 	trade Metal 543
 	trade Plastic 498
 	fleet "Small Southern Merchants" 2000
-	fleet "Large Northern Merchants" 3500
+	fleet "Large Southern Merchants" 3500
 	fleet "Small Southern Pirates" 3000
 	fleet "Small Militia" 5000
 	object
@@ -5496,7 +5496,7 @@ system Boral
 	trade Metal 511
 	trade Plastic 535
 	fleet "Small Southern Merchants" 3000
-	fleet "Large Northern Merchants" 8000
+	fleet "Large Southern Merchants" 8000
 	fleet "Small Southern Pirates" 1500
 	fleet "Small Militia" 10000
 	fleet "Human Miners" 2000

--- a/data/map.txt
+++ b/data/map.txt
@@ -24179,8 +24179,7 @@ planet Bounty
 planet Bourne
 	attributes rim factory urban
 	landscape land/city8
-	description `Bourne is a well-developed industrial world that was first settled four centuries ago. Its cities are home to some of the richest individuals in this section of the galaxy, but also home to tens of thousands of homeless people, and many others whose factory jobs are barely providing enough to make ends meet.`
-	description `	Outside the cities, the climate is somewhat dry, but the deep valleys and some coastal regions are suitable for farming. Very little of the planet remains that is untouched by human hands.`
+	description `Bourne is a well-developed industrial world that was first settled four centuries ago. Its cities are home to some of the richest individuals in this section of the galaxy, but also home to tens of thousands of homeless people, and many others whose factory jobs are barely providing enough to make ends meet. Outside the cities, the climate is somewhat dry, but the deep valleys and some coastal regions are suitable for farming. Very little of the planet remains that is untouched by human hands.`
 	spaceport `The spaceport on Bourne is a collection of granite and steel towers with platforms for ships to land. The tops of the towers are blackened by factory soot and etched by acid rain, but the granite gives them a timeless, classic look very unlike many of the ports you have visited.`
 	spaceport `	The port authorities warned you when you landed to be careful of pickpockets, so you are guarding your wallet very closely.`
 	outfitter "Common Outfits"
@@ -25870,8 +25869,7 @@ planet "New Holland"
 planet "New Iceland"
 	attributes "dirt belt" oil mining volcanic
 	landscape land/valley0
-	description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds.`
-	description `	Many of the inhabitants wear dust masks to avoid letting the particulate matter from the volcanoes accumulate in their lungs.`
+	description `New Iceland is a perpetually hazy volcanic world, with a slightly caustic atmosphere but enough reserves of metal and petrochemicals to draw a large number of settlers. Some of those settlers also make a living as farmers, and a few well-developed factory towns produce goods for export to other worlds. Many of the inhabitants wear dust masks to avoid letting the particulate matter from the volcanoes accumulate in their lungs.`
 	spaceport `Almost as soon as you stepped off your ship, your eyes began to sting. You try to breathe as shallowly as possible.`
 	spaceport `	This port consists of a single large hangar, only big enough for two or three bulk freighters, plus some overflow landing pads and old rusted storage sheds outside. There is a small cafeteria, offering you a choice between two kinds of soup, some pre-made sandwiches, or the hot meal of the day.`
 	security 0.05
@@ -27251,4 +27249,3 @@ planet Zug
 	tribute 1200
 		threshold 3000
 		fleet "Large Militia" 18
-

--- a/data/map.txt
+++ b/data/map.txt
@@ -13143,8 +13143,8 @@ system Kochab
 	trade Plastic 309
 	fleet "Small Southern Merchants" 2000
 	fleet "Large Southern Merchants" 6000
-	fleet "Small Southern Pirates" 5000
 	fleet "Small Militia" 6000
+	fleet "Small Southern Pirates" 5000
 	object
 		sprite star/k5
 		period 10

--- a/data/transport missions.txt
+++ b/data/transport missions.txt
@@ -1225,9 +1225,8 @@ mission "Rim Archaeology 5B"
 
 event "rim archaeology results"
 	planet Zug
-		attributes rim farming factory tourism
-		description `Zug is a pleasant world of rolling hills, fertile fields, and a few small oceans. Hundreds of millions of people live here, with more immigrants arriving every day, almost faster than the construction industry can keep up with them. In addition to the larger cities, many people live in smaller farming villages, making this one of the few worlds in the region that is truly self-sufficient both in industry and in agriculture.`
-		description `	The largest industry on Zug is Southbound Shipyards. However, in the wake of some extraordinary archaeological discoveries of a lost civilization, Zug has suddenly also become a popular destination for tourists.`
+		add attributes tourism
+		add description `	In the wake of some extraordinary archaeological discoveries of a lost civilization, Zug has suddenly also become a popular destination for tourists.`
 
 
 


### PR DESCRIPTION
Change static fleet clear + declare into incremental add/removes, even where the incremental syntax results in additional lines
 - Common human systems = common targets for mod fleet definitions
 - Initiate discussion over event scopes (e.g. "Should this really eliminate piracy in this sector?")
 
With the results of this PR, one would be able to add fleets to a system on a plugin's `map.txt` and they would generally persist, even after the FW campaign starts, or has completed. The sole exceptions are to the systems taken over by the pug at the end of the FW campaign.

Document with side-by-side changes, grouped by event, in event order of application: https://drive.google.com/open?id=0B2jPxN6TDvXPY3pxa2MxazFGVTg

**This PR utilizes the enhancements from #22 and won't work without them**