### PR TITLE
Add include required for compilation on Windows

### DIFF
--- a/source/ReportData.cpp
+++ b/source/ReportData.cpp
@@ -20,6 +20,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Ship.h"
 #include "System.h"
 
+#include <cmath>
 #include <iostream>
 #include <sstream>
 


### PR DESCRIPTION
Added cmath to the includes for ReportData.cpp to resolve an error at line 288 with `lround` not being declared in the context when compiling on Windows.