### PR TITLE
enhancement: Show ship positions in MapDetailPanel's orbits scene

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -47,29 +47,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 using namespace std;
 
-namespace {
-	int RadarType(const Ship &ship, int step)
-	{
-		if(ship.GetPersonality().IsTarget() && !ship.IsDestroyed())
-		{
-			// If a ship is a "target," double-blink it a few times per second.
-			int count = (step / 6) % 7;
-			if(count == 0 || count == 2)
-				return Radar::BLINK;
-		}
-		if(ship.IsDisabled() || (ship.IsOverheated() && ((step / 20) % 2)))
-			return Radar::INACTIVE;
-		if(ship.GetGovernment()->IsPlayer() || (ship.GetPersonality().IsEscort() && !ship.GetGovernment()->IsEnemy()))
-			return Radar::PLAYER;
-		if(!ship.GetGovernment()->IsEnemy())
-			return Radar::FRIENDLY;
-		auto target = ship.GetTargetShip();
-		if(target && target->GetGovernment()->IsPlayer())
-			return Radar::HOSTILE;
-		return Radar::UNFRIENDLY;
-	}
-}
-
 
 
 Engine::Engine(PlayerInfo &player)
@@ -812,6 +789,29 @@ void Engine::SelectGroup(int group, bool hasShift, bool hasControl)
 	groupSelect = group;
 	this->hasShift = hasShift;
 	this->hasControl = hasControl;
+}
+
+
+
+int Engine::RadarType(const Ship &ship, int step)
+{
+	if(ship.GetPersonality().IsTarget() && !ship.IsDestroyed())
+	{
+		// If a ship is a "target," double-blink it a few times per second.
+		int count = (step / 6) % 7;
+		if(count == 0 || count == 2)
+			return Radar::BLINK;
+	}
+	if(ship.IsDisabled() || (ship.IsOverheated() && ((step / 20) % 2)))
+		return Radar::INACTIVE;
+	if(ship.GetGovernment()->IsPlayer() || (ship.GetPersonality().IsEscort() && !ship.GetGovernment()->IsEnemy()))
+		return Radar::PLAYER;
+	if(!ship.GetGovernment()->IsEnemy())
+		return Radar::FRIENDLY;
+	auto target = ship.GetTargetShip();
+	if(target && target->GetGovernment()->IsPlayer())
+		return Radar::HOSTILE;
+	return Radar::UNFRIENDLY;
 }
 
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -816,6 +816,12 @@ int Engine::RadarType(const Ship &ship, int step)
 
 
 
+const list<shared_ptr<Ship>> &Engine::Ships() const
+{
+	return ships;
+}
+
+
 void Engine::EnterSystem()
 {
 	ai.Clean();

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -75,6 +75,8 @@ public:
 	void RClick(const Point &point);
 	void SelectGroup(int group, bool hasShift, bool hasControl);
 	
+	// Return the Radar color for a given ship on the given timestep.
+	static int RadarType(const Ship &ship, int step);
 	
 private:
 	void EnterSystem();

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -77,7 +77,8 @@ public:
 	
 	// Return the Radar color for a given ship on the given timestep.
 	static int RadarType(const Ship &ship, int step);
-	
+	// Return a read-only list of the currently placed ships.
+	const std::list<std::shared_ptr<Ship>> &Ships() const;
 private:
 	void EnterSystem();
 	

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -138,7 +138,7 @@ private:
 	Information info;
 	std::vector<Target> targets;
 	Point targetAngle;
-	Point targetUnit;
+	Point targetUnit = Point(0, -1);
 	EscortDisplay escorts;
 	std::vector<Status> statuses;
 	std::vector<PlanetLabel> labels;

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -76,14 +76,16 @@ void LoadPanel::Draw()
 	glClear(GL_COLOR_BUFFER_BIT);
 	GameData::Background().Draw(Point(), Point());
 	
+	const Font &font = FontSet::Get(14);
+	
 	Information info;
 	if(loadedInfo.IsLoaded())
 	{
-		info.SetString("pilot", loadedInfo.Name());
+		info.SetString("pilot", font.TruncateMiddle(loadedInfo.Name(), 165));
 		if(loadedInfo.ShipSprite())
 		{
 			info.SetSprite("ship sprite", loadedInfo.ShipSprite());
-			info.SetString("ship", loadedInfo.ShipName());
+			info.SetString("ship", font.TruncateMiddle(loadedInfo.ShipName(), 165));
 		}
 		if(!loadedInfo.GetSystem().empty())
 			info.SetString("system", loadedInfo.GetSystem());
@@ -107,8 +109,6 @@ void LoadPanel::Draw()
 	GameData::Interfaces().Get("menu background")->Draw(info, this);
 	GameData::Interfaces().Get("load menu")->Draw(info, this);
 	GameData::Interfaces().Get("menu player info")->Draw(info, this);
-	
-	const Font &font = FontSet::Get(14);
 	
 	// The list has space for 14 entries. Alpha should be 100% for Y = -157 to
 	// 103, and fade to 0 at 10 pixels beyond that.

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -61,7 +61,7 @@ void MainPanel::Step()
 	
 	if(show.Has(Command::MAP))
 	{
-		GetUI()->Push(new MapDetailPanel(player));
+		GetUI()->Push(new MapDetailPanel(player, nullptr, engine.Ships()));
 		isActive = false;
 	}
 	else if(show.Has(Command::INFO))

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -23,6 +23,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "MapOutfitterPanel.h"
 #include "MapShipyardPanel.h"
 #include "pi.h"
+#include "Person.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "PointerShader.h"
@@ -811,7 +812,7 @@ map<const System *, vector<shared_ptr<const Ship>>> MapDetailPanel::GetSystemShi
 				if(ship->GetSystem() && !ship->IsDestroyed() && ship->GetPersonality().IsEscort())
 					knownShipSystems[ship->GetSystem()].emplace_back(ship);
 	
-	// Add non-escort NPCs that are in "known" systems to the drawlist vectors.
+	// Add non-escort NPCs that are in "known" systems to the ship vectors.
 	for(const Mission &mission : player.Missions())
 		for(const NPC &npc : mission.NPCs())
 			for(const shared_ptr<const Ship> &ship : npc.Ships())
@@ -822,6 +823,15 @@ map<const System *, vector<shared_ptr<const Ship>>> MapDetailPanel::GetSystemShi
 					if(it != knownShipSystems.end())
 						it->second.emplace_back(ship);
 				}
+	
+	// Also add persons that are also in known systems.
+	for(const auto &pit : GameData::Persons())
+		if(!pit.second.IsDestroyed() && pit.second.GetShip()->GetSystem())
+		{
+			auto it = knownShipSystems.find(pit.second.GetShip()->GetSystem());
+			if(it != knownShipSystems.end())
+				it->second.emplace_back(pit.second.GetShip());
+		}
 	
 	return knownShipSystems;
 }

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -75,8 +75,8 @@ namespace {
 
 
 
-MapDetailPanel::MapDetailPanel(PlayerInfo &player, const System *system)
-	: MapPanel(player, system ? MapPanel::SHOW_REPUTATION : player.MapColoring(), system)
+MapDetailPanel::MapDetailPanel(PlayerInfo &player, const System *system, const list<shared_ptr<Ship>> &allShips)
+	: MapPanel(player, system ? MapPanel::SHOW_REPUTATION : player.MapColoring(), system, allShips)
 {
 }
 

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -731,6 +731,14 @@ void MapDetailPanel::DrawOrbits()
 		double scale = min(.5, min((HEIGHT - 2.) / shipSprite->Height(), (HEIGHT - 2.) / shipSprite->Width()));
 		SpriteShader::Draw(boxSprite, boxPos);
 		SpriteShader::Draw(shipSprite, shipPos, scale, selectedShip->GetSwizzle());
+		// Draw the ship's hardpoint sprites (pointing forward only).
+		for(const Hardpoint &weapon : selectedShip->Weapons())
+			if(weapon.GetOutfit() && weapon.GetOutfit()->HardpointSprite().HasSprite())
+				SpriteShader::Draw(
+					weapon.GetOutfit()->HardpointSprite().GetSprite(),
+					shipPos + 2 * scale * weapon.GetPoint(),
+					scale
+				);
 		
 		// Draw the ship's shields and hull as rings, as the targets interface does in-flight.
 		const bool isEnemy = selectedShip->GetGovernment()->Reputation() < 0.;

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -78,7 +78,20 @@ namespace {
 MapDetailPanel::MapDetailPanel(PlayerInfo &player, const System *system)
 	: MapPanel(player, system ? MapPanel::SHOW_REPUTATION : player.MapColoring(), system)
 {
+	// Set the list of ships which should be shown in the orbits scene.
 	shipSystems = GetSystemShipsDrawList();
+	if(commodity == SHOW_SHIP_LOCATIONS && !specialSystem && player.Flagship()
+			&& player.Flagship()->GetTargetShip() && player.Flagship()->GetTargetShip()->GetSystem())
+	{
+		const auto &systemIt = shipSystems.find(player.Flagship()->GetTargetShip()->GetSystem());
+		if(systemIt != shipSystems.end())
+		{
+			const auto shipIt = find(systemIt->second.cbegin(), systemIt->second.cend(),
+					player.Flagship()->GetTargetShip());
+			if(shipIt != systemIt->second.cend());
+				selectedShip = player.Flagship()->GetTargetShip().get();
+		}
+	}
 }
 
 
@@ -88,6 +101,7 @@ MapDetailPanel::MapDetailPanel(const MapPanel &panel)
 {
 	// Use whatever map coloring is specified in the PlayerInfo.
 	commodity = player.MapColoring();
+	// Set the list of ships which should be shown in the orbits scene.
 	shipSystems = GetSystemShipsDrawList();
 }
 

--- a/source/MapDetailPanel.h
+++ b/source/MapDetailPanel.h
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Point.h"
 
+#include <list>
 #include <map>
 #include <memory>
 
@@ -34,7 +35,7 @@ class System;
 // Ships in the system are drawn with PointerShader.
 class MapDetailPanel : public MapPanel {
 public:
-	explicit MapDetailPanel(PlayerInfo &player, const System *system = nullptr);
+	explicit MapDetailPanel(PlayerInfo &player, const System *system = nullptr, const std::list<std::shared_ptr<Ship>> &allShips = std::list<std::shared_ptr<Ship>>());
 	explicit MapDetailPanel(const MapPanel &panel);
 	
 	virtual void Draw() override;

--- a/source/MapDetailPanel.h
+++ b/source/MapDetailPanel.h
@@ -18,9 +18,13 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Point.h"
 
 #include <map>
+#include <memory>
+#include <vector>
 
 class Planet;
 class PlayerInfo;
+class Ship;
+class System;
 
 
 
@@ -28,6 +32,7 @@ class PlayerInfo;
 // stars based on attitude towards the player, government, or commodity price.
 // This panel also lets you view what planets are in each system, and you can
 // click on a planet to view its description.
+// Ships in the system are drawn with PointerShader.
 class MapDetailPanel : public MapPanel {
 public:
 	explicit MapDetailPanel(PlayerInfo &player, const System *system = nullptr);
@@ -47,6 +52,8 @@ private:
 	void DrawKey();
 	void DrawInfo();
 	void DrawOrbits();
+	void DrawShips(const Point &center, const double &scale);
+	std::map<const System *, std::vector<std::shared_ptr<const Ship>>> GetSystemShipsDrawList();
 	
 	// Set the commodity coloring, and update the player info as well.
 	void SetCommodity(int index);

--- a/source/MapDetailPanel.h
+++ b/source/MapDetailPanel.h
@@ -65,6 +65,7 @@ private:
 	
 	std::map<const Planet *, int> planetY;
 	std::map<const Planet *, Point> planets;
+	std::map<std::shared_ptr<const Ship>, Point> drawnShips;
 };
 
 

--- a/source/MapDetailPanel.h
+++ b/source/MapDetailPanel.h
@@ -19,7 +19,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <map>
 #include <memory>
-#include <vector>
 
 class Planet;
 class PlayerInfo;
@@ -48,12 +47,10 @@ protected:
 	
 	
 private:
-	void DoFind(const std::string &text);
 	void DrawKey();
 	void DrawInfo();
 	void DrawOrbits();
 	void DrawShips(const Point &center, const double &scale);
-	std::map<const System *, std::vector<std::shared_ptr<const Ship>>> GetSystemShipsDrawList();
 	
 	// Set the commodity coloring, and update the player info as well.
 	void SetCommodity(int index);

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -67,6 +67,13 @@ MapPanel::MapPanel(PlayerInfo &player, int commodity, const System *special)
 	// bought a map since the last time they viewed the map.
 	FogShader::Redraw();
 	
+	// If the player has a targeted ship and is using the orbits scene, start
+	// the map on the target ship's system, provided the target is not cloaked.
+	if(commodity == SHOW_SHIP_LOCATIONS && !specialSystem && player.Flagship()
+			&& player.Flagship()->GetTargetShip() && player.Flagship()->GetTargetShip()->GetSystem())
+		if(player.Flagship()->GetTargetShip()->Cloaking() < 1.)
+			selectedSystem = player.Flagship()->GetTargetShip()->GetSystem();
+	
 	if(selectedSystem)
 		center = Point(0., 0.) - selectedSystem->Position();
 }

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -20,7 +20,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Point.h"
 
 #include <map>
+#include <memory>
 #include <string>
+#include <vector>
 
 class Angle;
 class Government;
@@ -44,6 +46,7 @@ public:
 	static const int SHOW_SPECIAL = -4;
 	static const int SHOW_GOVERNMENT = -5;
 	static const int SHOW_REPUTATION = -6;
+	static const int SHOW_SHIP_LOCATIONS = -7;
 	
 	static const double OUTER;
 	static const double INNER;
@@ -69,6 +72,7 @@ protected:
 	static Color MapColor(double value);
 	static Color ReputationColor(double reputation, bool canLand, bool hasDominated);
 	static Color GovernmentColor(const Government *government);
+	static Color ShipColor(int64_t ownedCost, int64_t hostileCost, int64_t totalCost);
 	static Color UninhabitedColor();
 	static Color UnexploredColor();
 	
@@ -105,6 +109,8 @@ protected:
 	std::string buttonCondition;
 	
 	std::map<const Government *, double> closeGovernments;
+	// Map of where the player knows ships' location.
+	std::map<const System *, std::vector<std::shared_ptr<const Ship>>> shipSystems;
 	
 	
 private:

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -97,6 +97,7 @@ protected:
 	const System *selectedSystem;
 	const System *specialSystem;
 	const Planet *selectedPlanet = nullptr;
+	const Ship *selectedShip = nullptr;
 	
 	Point center;
 	int commodity;

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -19,6 +19,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "DistanceMap.h"
 #include "Point.h"
 
+#include <list>
 #include <map>
 #include <memory>
 #include <string>
@@ -53,7 +54,7 @@ public:
 	
 	
 public:
-	explicit MapPanel(PlayerInfo &player, int commodity = SHOW_REPUTATION, const System *special = nullptr);
+	explicit MapPanel(PlayerInfo &player, int commodity = SHOW_REPUTATION, const System *special = nullptr, const std::list<std::shared_ptr<Ship>> &allShips = std::list<std::shared_ptr<Ship>>());
 	
 	virtual void Draw() override;
 	
@@ -111,6 +112,7 @@ protected:
 	std::map<const Government *, double> closeGovernments;
 	// Map of where the player knows ships' location.
 	std::map<const System *, std::vector<std::shared_ptr<const Ship>>> shipSystems;
+	std::list<std::shared_ptr<Ship>> ships;
 	
 	
 private:

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -122,6 +122,7 @@ private:
 	void DrawMissions();
 	void DrawPointer(const System *system, Angle &angle, const Color &color, bool bigger = false);
 	static void DrawPointer(Point position, Angle &angle, const Color &color, bool drawBack = true, bool bigger = false);
+	std::map<const System *, std::vector<std::shared_ptr<const Ship>>> GetSystemShipsDrawList();
 };
 
 

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -28,7 +28,7 @@ class Sprite;
 
 
 
-// Base class for the maps os shipyards and outfitters.
+// Base class for the maps of shipyards and outfitters.
 class MapSalesPanel : public MapPanel {
 public:
 	MapSalesPanel(PlayerInfo &player, bool isOutfitters);

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -85,16 +85,18 @@ void MenuPanel::Draw()
 	glClear(GL_COLOR_BUFFER_BIT);
 	GameData::Background().Draw(Point(), Point());
 	
+	const Font &font = FontSet::Get(14);
+	
 	Information info;
 	if(player.IsLoaded() && !player.IsDead())
 	{
 		info.SetCondition("pilot loaded");
-		info.SetString("pilot", player.FirstName() + " " + player.LastName());
+		info.SetString("pilot", font.TruncateMiddle(player.FirstName() + " " + player.LastName(), 165));
 		if(player.Flagship())
 		{
 			const Ship &flagship = *player.Flagship();
 			info.SetSprite("ship sprite", flagship.GetSprite());
-			info.SetString("ship", flagship.Name());
+			info.SetString("ship", font.TruncateMiddle(flagship.Name(), 165));
 		}
 		if(player.GetSystem())
 			info.SetString("system", player.GetSystem()->Name());
@@ -106,7 +108,7 @@ void MenuPanel::Draw()
 	else if(player.IsLoaded())
 	{
 		info.SetCondition("no pilot loaded");
-		info.SetString("pilot", player.FirstName() + " " + player.LastName());
+		info.SetString("pilot", font.TruncateMiddle(player.FirstName() + " " + player.LastName(), 165));
 		info.SetString("ship", "You have died.");
 	}
 	else
@@ -133,7 +135,6 @@ void MenuPanel::Draw()
 		}
 	}
 	
-	const Font &font = FontSet::Get(14);
 	int y = 120 - scroll / scrollSpeed;
 	for(const string &line : credits)
 	{

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -538,7 +538,7 @@ bool ShopPanel::Click(int x, int y, int clicks)
 	// Handle clicks on the buttons.
 	if(x >= Screen::Right() - SIDE_WIDTH && y >= Screen::Bottom() - BUTTON_HEIGHT)
 	{
-		// Make sure the click was actually within the bottons, not the space
+		// Make sure the click was actually within the buttons, not the space
 		// above them that shows your credits or the padding below them.
 		if(y < Screen::Bottom() - 40 || y >= Screen::Bottom() - 10)
 			return true;


### PR DESCRIPTION
WIP for endless-sky#2678

TODO: 
 - display regular NPCs in known systems
 - Reorder the shipSystems construction to prevent setting the system to that of a targeted ship that cannot be tracked (e.g. call from MapPanel constructor and not MapDetailPanel constructor)
 
Done:
 - Show unparked player ships
 - Show NPCs marked `personality escort`
 - Show "Person" ships that are in known systems.
 - Show non-cloaked mission NPCs in systems with either player ships or escorts
 - Set the selected ship to be the flagship's target ship
 - Display information about the selected ship
 - Draw the selected ship's swizzled sprite
 - Commodity coloring by "system has escorts", so the player does not need to go on a guessing game to find systems with selectable ships. Color is chosen based on cost comparison between the hostile ships, player escorts (owned and personality), and total in-system mission NPCs. Disabled ships contribute only a portion of their cost.
 - Ship hardpoint sprites are shown in the default point-forward orientation.
 - When constructing the MapDetailPanel, if the flagship's target ship can be selected, select it (i.e. the reverse of the closing behavior where the last selected ship is the flagship's new target).